### PR TITLE
Feat/#55 주간챌린지 생성 서버연결

### DIFF
--- a/NEMODU/NEMODU.xcodeproj/project.pbxproj
+++ b/NEMODU/NEMODU.xcodeproj/project.pbxproj
@@ -150,6 +150,8 @@
 		23F5718828AA6DEE005F2E21 /* MyAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F5718728AA6DEE005F2E21 /* MyAnnotationView.swift */; };
 		23F6959C28C9F6A7008D1378 /* UserInfoSettingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F6959B28C9F6A7008D1378 /* UserInfoSettingVC.swift */; };
 		37783E39C7DFB38581CA78A2 /* Pods_NEMODU.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7400965811C32403A72B2B0 /* Pods_NEMODU.framework */; };
+		3C0029F1290110AE001BB6AE /* CreateWeekChallengeVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0029F0290110AE001BB6AE /* CreateWeekChallengeVM.swift */; };
+		3C0029F329011378001BB6AE /* CreatChallengeResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0029F229011378001BB6AE /* CreatChallengeResponseModel.swift */; };
 		3C05FFEB28B71F4F0017F4E1 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C05FFEA28B71F4F0017F4E1 /* PaddingLabel.swift */; };
 		3C05FFED28B7324D0017F4E1 /* ChallengeTermButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C05FFEC28B7324D0017F4E1 /* ChallengeTermButtonView.swift */; };
 		3C05FFEF28B74E2B0017F4E1 /* CreateChallengeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C05FFEE28B74E2B0017F4E1 /* CreateChallengeVC.swift */; };
@@ -351,6 +353,8 @@
 		23F5718528AA6DAD005F2E21 /* MyAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAnnotation.swift; sourceTree = "<group>"; };
 		23F5718728AA6DEE005F2E21 /* MyAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAnnotationView.swift; sourceTree = "<group>"; };
 		23F6959B28C9F6A7008D1378 /* UserInfoSettingVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoSettingVC.swift; sourceTree = "<group>"; };
+		3C0029F0290110AE001BB6AE /* CreateWeekChallengeVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateWeekChallengeVM.swift; sourceTree = "<group>"; };
+		3C0029F229011378001BB6AE /* CreatChallengeResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatChallengeResponseModel.swift; sourceTree = "<group>"; };
 		3C05FFEA28B71F4F0017F4E1 /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		3C05FFEC28B7324D0017F4E1 /* ChallengeTermButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeTermButtonView.swift; sourceTree = "<group>"; };
 		3C05FFEE28B74E2B0017F4E1 /* CreateChallengeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateChallengeVC.swift; sourceTree = "<group>"; };
@@ -940,10 +944,10 @@
 		3C02802D28B507D5002BF37C /* CreateChallenge */ = {
 			isa = PBXGroup;
 			children = (
-				3CF431C128FE93D3007EB115 /* ChallengeVC.swift */,
 				3CACEBD228C9E9E6001F5109 /* View */,
-				3CC1EC7128D0678C007C87F6 /* CreateWeekChallenge */,
+				3CF431C128FE93D3007EB115 /* ChallengeVC.swift */,
 				3CC1EC7028D0675D007C87F6 /* SelectChallengeType */,
+				3CC1EC7128D0678C007C87F6 /* CreateWeekChallenge */,
 				3C05FFEE28B74E2B0017F4E1 /* CreateChallengeVC.swift */,
 				3C9FD39C28B68D19006FA812 /* ChallengePeriodVC.swift */,
 				3C05FFF228B7C79A0017F4E1 /* SelectFriendsVC.swift */,
@@ -986,6 +990,7 @@
 		3C2A262F28FF8BB5009E0069 /* Challenge */ = {
 			isa = PBXGroup;
 			children = (
+				3C0029F0290110AE001BB6AE /* CreateWeekChallengeVM.swift */,
 			);
 			path = Challenge;
 			sourceTree = "<group>";
@@ -1122,6 +1127,7 @@
 		3C3BD77A28B3A53400AD55B6 /* Response */ = {
 			isa = PBXGroup;
 			children = (
+				3C0029F229011378001BB6AE /* CreatChallengeResponseModel.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1382,6 +1388,7 @@
 				2348B41E2892DF0D001095BC /* MypageVC.swift in Sources */,
 				23F5716928A6802C005F2E21 /* UIStackView+.swift in Sources */,
 				23B7206B28A12BCD00D3A410 /* MainVC.swift in Sources */,
+				3C0029F329011378001BB6AE /* CreatChallengeResponseModel.swift in Sources */,
 				2348B3F52892D131001095BC /* Service.swift in Sources */,
 				3C48920528B0C8A800B11207 /* NoChallengeStatusMessage.swift in Sources */,
 				23D8B7E528B4D5AA00F48165 /* CalendarSelectStackView.swift in Sources */,
@@ -1514,6 +1521,7 @@
 				23255A8228D0DCE9005D6D5A /* UserDataModel.swift in Sources */,
 				3C72D7C028B50993006E2229 /* ChallengeRankingNC.swift in Sources */,
 				23F5717928A94AA5005F2E21 /* UIString+.swift in Sources */,
+				3C0029F1290110AE001BB6AE /* CreateWeekChallengeVM.swift in Sources */,
 				3CB9DB9C28A92528007BC1BE /* MenuBarCVC.swift in Sources */,
 				230CB2E128AD474E00B11270 /* ChallengeBlockResponseModel.swift in Sources */,
 				237573F928FC0113006026ED /* TabView.swift in Sources */,

--- a/NEMODU/NEMODU/Global/Enum/AlertType.swift
+++ b/NEMODU/NEMODU/Global/Enum/AlertType.swift
@@ -14,6 +14,7 @@ enum AlertType {
     case minimumBlocks
     case speedWarning
     case realTimeChallenge
+    case createWeekChallenge
 }
 
 extension AlertType {
@@ -31,6 +32,8 @@ extension AlertType {
             return "혹시 자동차나 자전거를\n타고 계신가요?"
         case .realTimeChallenge:
             return "준비중"
+        case .createWeekChallenge:
+            return "주간 챌린지 생성 실패"
         }
     }
     
@@ -48,6 +51,8 @@ extension AlertType {
             return "속도가 너무 빠른 경우\n기록이 일시정지됩니다.\n\n네모두는 산책, 달리기 기록만\n측정가능합니다.\n🏃우리 함께 걸어보아요!🏃‍♀️ "
         case .realTimeChallenge:
             return "조금만 기다려주세요🏃‍♀️"
+        case .createWeekChallenge:
+            return "생성에 오류가 발생하였습니다"
         }
     }
     
@@ -57,7 +62,7 @@ extension AlertType {
             return "시스템 설정 가기"
         case .recordNetworkError:
             return "다시 저장하기"
-        case .defaultNetworkError, .realTimeChallenge:
+        case .defaultNetworkError, .realTimeChallenge, .createWeekChallenge:
             return "확인"
         case .minimumBlocks, .speedWarning:
             return "계속 하기"
@@ -70,7 +75,7 @@ extension AlertType {
             return "다음에"
         case .recordNetworkError:
             return "그냥 나가기"
-        case .defaultNetworkError, .realTimeChallenge:
+        case .defaultNetworkError, .realTimeChallenge, .createWeekChallenge:
             return nil
         case .minimumBlocks, .speedWarning:
             return "기록 끝내기"

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Request/CreateChallengeRequestModel.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Request/CreateChallengeRequestModel.swift
@@ -6,9 +6,23 @@
 //
 
 import Foundation
+import Alamofire
 
 struct CreateChallengeRequestModel: Codable {
     var friends: [String]
     var message, name, nickname, started: String
-    var type: String
+    let type: String
+}
+
+extension CreateChallengeRequestModel {
+    var createChallenge: Parameters {
+        return [
+          "friends": friends,
+          "message": message,
+          "name": name,
+          "nickname": nickname,
+          "started": started,
+          "type": type
+        ]
+    }
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/CreatChallengeResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/CreatChallengeResponseModel.swift
@@ -1,0 +1,21 @@
+//
+//  CreatChallengeResponseModel.swift
+//  NEMODU
+//
+//  Created by Kim HeeJae on 2022/10/20.
+//
+
+import Foundation
+import Alamofire
+
+struct CreatChallengeResponseModel: Codable {
+    let users: [ChallengeUser]
+    let message, started, ended: String
+}
+
+// MARK: - User
+
+struct ChallengeUser: Codable {
+    let nickname: String
+    let picturePath: String
+}

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/ChallengePeriodVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/ChallengePeriodVC.swift
@@ -45,7 +45,6 @@ class ChallengePeriodVC: CreateChallengeVC {
     lazy var endChallengeButtonView = ChallengeTermButtonView()
         .then {
             $0.titleLabel.text = "챌린지 종료일"
-            $0.actionButton.addTarget(self, action: #selector(didTapStartChallengeButton), for: .touchUpInside)
         }
     
     let guideLabel = PaddingLabel()
@@ -67,6 +66,7 @@ class ChallengePeriodVC: CreateChallengeVC {
     var datePickerContainerHeightConstraint: Constraint?
     
     var started, ended: String?
+    var startedDate: Date?
     
     // MARK: - Life Cycle
     
@@ -162,6 +162,7 @@ class ChallengePeriodVC: CreateChallengeVC {
         dateFormatter.dateStyle = .medium
         dateFormatter.dateFormat = "yyyy년 MM월 dd일"
         
+        startedDate = datePicker.date
         let selectedDate = datePicker.date
         started = dateFormatter.string(from: selectedDate)
         startChallengeButtonView.settingLabel.text = started
@@ -182,6 +183,7 @@ class ChallengePeriodVC: CreateChallengeVC {
         // 선택된 날짜 챌린지 생성 VC로 전달하기
         createWeekChallengeVC?.started = started
         createWeekChallengeVC?.ended = ended
+        createWeekChallengeVC?.startedDate = startedDate
         
         dismiss(animated: true)
     }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateChallengeSuccuessVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateChallengeSuccuessVC.swift
@@ -15,7 +15,7 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
     
     // MARK: - UI components
     
-    let successTitleLabel = PaddingLabel()
+    private let successTitleLabel = PaddingLabel()
         .then {
             $0.text = "주간 챌린지가 \n만들어졌습니다!"
             $0.numberOfLines = 2
@@ -27,19 +27,19 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
             $0.backgroundColor = .clear
         }
     
-    let successIconImageView = UIImageView()
+    private let successIconImageView = UIImageView()
         .then {
             $0.image = UIImage(named: "checkCircle")?.withRenderingMode(.alwaysTemplate)
             $0.tintColor = .main
         }
     
-    let informationContainerView = UIView()
+    private let informationContainerView = UIView()
         .then {
             $0.backgroundColor = .gray50
             $0.layer.cornerRadius = 16
         }
     
-    let challengeTitleLabel = PaddingLabel()
+    private let challengeTitleLabel = PaddingLabel()
         .then {
             $0.text = "가즈아!"
             $0.font = .body1
@@ -47,7 +47,7 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
             
             $0.backgroundColor = .clear
         }
-    let challengeDateLabel = PaddingLabel()
+    private let challengeDateLabel = PaddingLabel()
         .then {
             $0.text = "8월 22일 - 8월 29일" // TODO: - 추후 기본 표시값 수정
             $0.font = .body4
@@ -55,17 +55,17 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
             
             $0.backgroundColor = .clear
         }
-    let userProfileStackView = UIStackView()
+    private let userProfileStackView = UIStackView()
         .then {
             $0.axis = .horizontal
             $0.spacing = 16
             $0.alignment = .fill
         }
-    let separateView = UIView()
+    private let separateView = UIView()
         .then {
             $0.backgroundColor = .gray300
         }
-    let explainLabel = PaddingLabel()
+    private let explainLabel = PaddingLabel()
         .then {
             $0.text = "챌린지 시작일까지 수락한 친구들과 함께\n 챌린지가 진행됩니다."
             $0.numberOfLines = 2
@@ -84,18 +84,53 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
         super.viewDidLoad()
     }
     
-    // MARK: - Functions
-    
     override func configureView() {
         super.configureView()
         
+        configureNavigationBar()
+        configureConfirmButton()
+    }
+    
+    override func layoutView() {
+        super.layoutView()
+        
+        configureLayout()
+    }
+    
+    // MARK: - Functions
+    
+    override func didTapConfirmButton() {
+        dismiss(animated: true, completion: { [self] in
+            createWeekChallengeVC?.navigationController?.popToRootViewController(animated: true)
+        })
+    }
+    
+}
+
+// MARK: - Configure
+
+extension CreateChallengeSuccuessVC {
+    
+    func configureCreateChallengeResponse(creatChallengeResponseModel: CreatChallengeResponseModel) {
+        challengeTitleLabel.text = creatChallengeResponseModel.message
+        
+        let startDate = creatChallengeResponseModel.started.split(separator: "-")
+        let endDate = creatChallengeResponseModel.ended.split(separator: "-")
+        challengeDateLabel.text = "\(startDate[1])월 \(startDate[2])일 - \(endDate[1])월 \(endDate[2])일"
+        
+        configureJoinUserInfo(joinUsersInfo: creatChallengeResponseModel.users)
+    }
+    
+    private func configureNavigationBar() {
         _ = navigationBar
             .then {
                 $0.naviType = .present
                 $0.configureNaviBar(targetVC: self, title: "주간 챌린지 만들기")
                 $0.configureBackBtn(targetVC: self)
             }
-        
+    }
+    
+    private func configureConfirmButton() {
         _ = confirmButton
             .then {
                 $0.setTitle("확인", for: .normal)
@@ -103,18 +138,20 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
                 
                 $0.isSelected = true
             }
-        
-        for userProfile in 1...3 {
+    }
+    
+    private func configureJoinUserInfo(joinUsersInfo: [ChallengeUser]) {
+        for joinUserInfo in joinUsersInfo {
             let containerView = UIView()
             let profileImage = UIImageView()
                 .then {
-                    $0.image = UIImage(named: "defaultThumbnail")
+                    $0.kf.setImage(with: URL(string: joinUserInfo.picturePath))
                     $0.layer.cornerRadius = 28
                     $0.layer.masksToBounds = true
                 }
             let nicknameLabel = PaddingLabel()
                 .then {
-                    $0.text = "아무개 \(userProfile)"
+                    $0.text = joinUserInfo.nickname
                     $0.font = .caption1
                     $0.textColor = .gray900
                 }
@@ -133,13 +170,16 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
             }
             
             userProfileStackView.addArrangedSubview(containerView)
-            
         }
     }
     
-    override func layoutView() {
-        super.layoutView()
-        
+}
+
+// MARK: - Layout
+
+extension CreateChallengeSuccuessVC {
+    
+    private func configureLayout() {
         view.addSubviews([successTitleLabel, successIconImageView, informationContainerView])
         informationContainerView.addSubviews([challengeTitleLabel, challengeDateLabel, userProfileStackView, separateView, explainLabel])
         
@@ -185,13 +225,6 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
             $0.top.equalTo(separateView.snp.bottom).offset(20)
             $0.bottom.equalTo(informationContainerView.snp.bottom).inset(28)
         }
-    }
-    
-    override func didTapConfirmButton() {
-        dismiss(animated: true, completion: { [self] in
-            createWeekChallengeVC?.navigationController?.popToRootViewController(animated: true)
-        })
-        
     }
     
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateChallengeVC.swift
@@ -69,6 +69,7 @@ class CreateChallengeVC: BaseViewController {
         }
     }
     
+    /// override when class inheritance for request create challenge
     @objc
     func didTapConfirmButton() {
     }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateAccumulateChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateAccumulateChallengeVC.swift
@@ -33,4 +33,9 @@ class CreateAccumulateChallengeVC: CreateWeekChallengeVC {
                 $0.titleLabel.text = "칸 많이 누적하기 챌린지"
             }
     }
+    
+    override func didTapConfirmButton() {
+        requestCreateWeekChallenge(type: "Accumulate")
+    }
+    
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWidenChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWidenChallengeVC.swift
@@ -22,7 +22,7 @@ class CreateWidenChallengeVC: CreateWeekChallengeVC {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-    
+     
     // MARK: - Functions
     
     override func configureView() {
@@ -33,4 +33,9 @@ class CreateWidenChallengeVC: CreateWeekChallengeVC {
                 $0.titleLabel.text = "영역 넓히기 챌린지"
             }
     }
+    
+    override func didTapConfirmButton() {
+        requestCreateWeekChallenge(type: "Widen")
+    }
+    
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewModel/Challenge/CreateWeekChallengeVM.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewModel/Challenge/CreateWeekChallengeVM.swift
@@ -66,7 +66,6 @@ extension CreateWeekChallengeVM {
                 
                 switch result {
                 case .failure(let error):
-                    dump(error)
                     owner.apiError.onError(error)
                     owner.output.isCreateWeekChallengeSuccess.accept(false)
                 case .success(let data):

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewModel/Challenge/CreateWeekChallengeVM.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewModel/Challenge/CreateWeekChallengeVM.swift
@@ -1,0 +1,78 @@
+//
+//  CreateWeekChallengeVM.swift
+//  NEMODU
+//
+//  Created by Kim HeeJae on 2022/10/20.
+//
+
+import Foundation
+import RxCocoa
+import RxSwift
+
+final class CreateWeekChallengeVM: BaseViewModel {
+    var apiSession: APIService = APISession()
+    let apiError = PublishSubject<APIError>()
+    
+    var bag = DisposeBag()
+    
+    var input = Input()
+    var output = Output()
+    
+    // MARK: - Input
+    
+    struct Input {}
+    
+    // MARK: - Output
+    
+    struct Output {
+        var isCreateWeekChallengeSuccess = PublishRelay<Bool>()
+        var successWithResponseData = PublishRelay<CreatChallengeResponseModel>()
+    }
+    
+    // MARK: - Init
+    
+    init() {
+        bindInput()
+        bindOutput()
+    }
+    
+    deinit {
+        bag = DisposeBag()
+    }
+}
+
+// MARK: - Input
+
+extension CreateWeekChallengeVM: Input {
+    func bindInput() {}
+}
+
+// MARK: - Output
+
+extension CreateWeekChallengeVM: Output {
+    func bindOutput() {}
+}
+
+// MARK: - Networking
+
+extension CreateWeekChallengeVM {
+    func requestCreateWeekChallengeVM(with param: CreateChallengeRequestModel) {
+        let path = "challenge/"
+        let resource = urlResource<CreatChallengeResponseModel>(path: path)
+        
+        apiSession.postRequest(with: resource, param: param.createChallenge)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                
+                switch result {
+                case .failure(let error):
+                    dump(error)
+                    owner.apiError.onError(error)
+                    owner.output.isCreateWeekChallengeSuccess.accept(false)
+                case .success(let data):
+                    owner.output.successWithResponseData.accept(data)
+                }
+            })
+            .disposed(by: bag)
+    }
+}

--- a/NEMODU/NEMODU/Screen/Share/View/AlertVC.swift
+++ b/NEMODU/NEMODU/Screen/Share/View/AlertVC.swift
@@ -123,7 +123,7 @@ extension AlertVC {
         normalBtn.setTitle(alertType.normalBtnTitle, for: .normal)
         switch alertType {
         // 버튼 한 개
-        case .defaultNetworkError, .realTimeChallenge:
+        case .defaultNetworkError, .realTimeChallenge, .createWeekChallenge:
             btnStackView.addArrangedSubview(highlightBtn)
         // 버튼 세로 두 개
         case .requestAuthority:


### PR DESCRIPTION
## PR 요약
주간 챌린지 생성 리팩토링 및 서버연결
- 챌린지 제목, 내용, 닐짜 선택이 있어야만 확인 버튼 활성화
- 오해 방지를 위해 날짜설정에 있는 종료일 버튼 비활성화(디자이너 피드백)
- 친구목록 불러오기 서버 미연결
- 특정 상황에서의 레이아웃 오류 수정은 추후 작업예정

## 변경 사항
- Enum에 주간 챌린지 생성 실패 알람 case 추가

##  ScreenShot
<img width="435" alt="image" src="https://user-images.githubusercontent.com/26570294/198684957-271bd1f6-f7b2-44c2-8544-5804b92c7416.png">

#### Linked Issue
close `#55`

