### PR TITLE
Feat/#80 챌린지 목록 리팩토링 및 서버연결

### DIFF
--- a/NEMODU/NEMODU.xcodeproj/project.pbxproj
+++ b/NEMODU/NEMODU.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		3C05FFF128B794390017F4E1 /* CreateChallengeSuccuessVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C05FFF028B794390017F4E1 /* CreateChallengeSuccuessVC.swift */; };
 		3C05FFF328B7C79A0017F4E1 /* SelectFriendsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C05FFF228B7C79A0017F4E1 /* SelectFriendsVC.swift */; };
 		3C05FFF528B7E0900017F4E1 /* SelectFriendsTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C05FFF428B7E0900017F4E1 /* SelectFriendsTVC.swift */; };
+		3C064BBD290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C064BBC290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift */; };
 		3C08137B28A91C00009F854B /* ChallengeRankingMenuBarCV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C08136A28A91C00009F854B /* ChallengeRankingMenuBarCV.swift */; };
 		3C08137D28A91C00009F854B /* NoListStatusTVFV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C08136F28A91C00009F854B /* NoListStatusTVFV.swift */; };
 		3C08137E28A91C00009F854B /* ChallengeTitleTVHV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C08137028A91C00009F854B /* ChallengeTitleTVHV.swift */; };
@@ -192,6 +193,8 @@
 		3C9FD39B28B64363006FA812 /* CreateChallengeListButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9FD39A28B64363006FA812 /* CreateChallengeListButtonView.swift */; };
 		3C9FD39D28B68D19006FA812 /* ChallengePeriodVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9FD39C28B68D19006FA812 /* ChallengePeriodVC.swift */; };
 		3CACEBD428C9EAA0001F5109 /* FriendListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CACEBD328C9EAA0001F5109 /* FriendListView.swift */; };
+		3CB766BB290E73B700EAE812 /* ChallengeVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB766BA290E73B700EAE812 /* ChallengeVM.swift */; };
+		3CB766BD290E773600EAE812 /* WaitChallengeListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB766BC290E773600EAE812 /* WaitChallengeListResponseModel.swift */; };
 		3CB9DB9C28A92528007BC1BE /* MenuBarCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB9DB9A28A92527007BC1BE /* MenuBarCVC.swift */; };
 		3CB9DB9D28A92528007BC1BE /* MenuBarCV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB9DB9B28A92527007BC1BE /* MenuBarCV.swift */; };
 		3CB9DB9F28A93F19007BC1BE /* ChallengeRankingMenuBarCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB9DB9E28A93F19007BC1BE /* ChallengeRankingMenuBarCVC.swift */; };
@@ -361,6 +364,7 @@
 		3C05FFF028B794390017F4E1 /* CreateChallengeSuccuessVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateChallengeSuccuessVC.swift; sourceTree = "<group>"; };
 		3C05FFF228B7C79A0017F4E1 /* SelectFriendsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectFriendsVC.swift; sourceTree = "<group>"; };
 		3C05FFF428B7E0900017F4E1 /* SelectFriendsTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectFriendsTVC.swift; sourceTree = "<group>"; };
+		3C064BBC290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressAndDoneChallengeListResponseModel.swift; sourceTree = "<group>"; };
 		3C08136A28A91C00009F854B /* ChallengeRankingMenuBarCV.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChallengeRankingMenuBarCV.swift; sourceTree = "<group>"; };
 		3C08136F28A91C00009F854B /* NoListStatusTVFV.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoListStatusTVFV.swift; sourceTree = "<group>"; };
 		3C08137028A91C00009F854B /* ChallengeTitleTVHV.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChallengeTitleTVHV.swift; sourceTree = "<group>"; };
@@ -401,6 +405,8 @@
 		3C9FD39A28B64363006FA812 /* CreateChallengeListButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateChallengeListButtonView.swift; sourceTree = "<group>"; };
 		3C9FD39C28B68D19006FA812 /* ChallengePeriodVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengePeriodVC.swift; sourceTree = "<group>"; };
 		3CACEBD328C9EAA0001F5109 /* FriendListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListView.swift; sourceTree = "<group>"; };
+		3CB766BA290E73B700EAE812 /* ChallengeVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeVM.swift; sourceTree = "<group>"; };
+		3CB766BC290E773600EAE812 /* WaitChallengeListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitChallengeListResponseModel.swift; sourceTree = "<group>"; };
 		3CB9DB9A28A92527007BC1BE /* MenuBarCVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuBarCVC.swift; sourceTree = "<group>"; };
 		3CB9DB9B28A92527007BC1BE /* MenuBarCV.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuBarCV.swift; sourceTree = "<group>"; };
 		3CB9DB9E28A93F19007BC1BE /* ChallengeRankingMenuBarCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeRankingMenuBarCVC.swift; sourceTree = "<group>"; };
@@ -945,13 +951,8 @@
 			isa = PBXGroup;
 			children = (
 				3CACEBD228C9E9E6001F5109 /* View */,
-				3CF431C128FE93D3007EB115 /* ChallengeVC.swift */,
 				3CC1EC7028D0675D007C87F6 /* SelectChallengeType */,
 				3CC1EC7128D0678C007C87F6 /* CreateWeekChallenge */,
-				3C05FFEE28B74E2B0017F4E1 /* CreateChallengeVC.swift */,
-				3C9FD39C28B68D19006FA812 /* ChallengePeriodVC.swift */,
-				3C05FFF228B7C79A0017F4E1 /* SelectFriendsVC.swift */,
-				3C05FFF028B794390017F4E1 /* CreateChallengeSuccuessVC.swift */,
 			);
 			path = CreateChallenge;
 			sourceTree = "<group>";
@@ -991,6 +992,7 @@
 			isa = PBXGroup;
 			children = (
 				3C0029F0290110AE001BB6AE /* CreateWeekChallengeVM.swift */,
+				3CB766BA290E73B700EAE812 /* ChallengeVM.swift */,
 			);
 			path = Challenge;
 			sourceTree = "<group>";
@@ -1096,9 +1098,10 @@
 		3C3BD77728B396B100AD55B6 /* Challenge */ = {
 			isa = PBXGroup;
 			children = (
-				3C02802D28B507D5002BF37C /* CreateChallenge */,
 				3C48920B28B101D100B11207 /* ChallengeListTypeMenuBarCV.swift */,
+				3CF431C128FE93D3007EB115 /* ChallengeVC.swift */,
 				3C08136E28A91C00009F854B /* ChallengeTV */,
+				3C02802D28B507D5002BF37C /* CreateChallenge */,
 			);
 			path = Challenge;
 			sourceTree = "<group>";
@@ -1128,6 +1131,8 @@
 			isa = PBXGroup;
 			children = (
 				3C0029F229011378001BB6AE /* CreatChallengeResponseModel.swift */,
+				3CB766BC290E773600EAE812 /* WaitChallengeListResponseModel.swift */,
+				3C064BBC290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1207,6 +1212,10 @@
 				3C9FD39828B640D7006FA812 /* CreateWeekChallengeVC.swift */,
 				3CC1EC7228D06811007C87F6 /* CreateWidenChallengeVC.swift */,
 				3CC1EC7428D06917007C87F6 /* CreateAccumulateChallengeVC.swift */,
+				3C05FFEE28B74E2B0017F4E1 /* CreateChallengeVC.swift */,
+				3C9FD39C28B68D19006FA812 /* ChallengePeriodVC.swift */,
+				3C05FFF228B7C79A0017F4E1 /* SelectFriendsVC.swift */,
+				3C05FFF028B794390017F4E1 /* CreateChallengeSuccuessVC.swift */,
 			);
 			path = CreateWeekChallenge;
 			sourceTree = "<group>";
@@ -1364,6 +1373,7 @@
 				237573E928F92A1B006026ED /* NicknameCheckView.swift in Sources */,
 				3C3BD77428B3754A00AD55B6 /* RankingListRequestModel.swift in Sources */,
 				2375740328FC43C0006026ED /* FriendRequestTVC.swift in Sources */,
+				3CB766BD290E773600EAE812 /* WaitChallengeListResponseModel.swift in Sources */,
 				23B7207028A12DBB00D3A410 /* RecordView.swift in Sources */,
 				231A2B8D28B20B3E00FF884B /* ProfileView.swift in Sources */,
 				23F5718228AA6038005F2E21 /* UIImage+.swift in Sources */,
@@ -1510,6 +1520,7 @@
 				3C9FD39D28B68D19006FA812 /* ChallengePeriodVC.swift in Sources */,
 				2348B3FD2892D16C001095BC /* Loadable.swift in Sources */,
 				2375740528FC4856006026ED /* FriendListTVC.swift in Sources */,
+				3C064BBD290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift in Sources */,
 				2348B4012892D1A6001095BC /* UITextField+.swift in Sources */,
 				23F5717528A92D4A005F2E21 /* ProfileRecordStackView.swift in Sources */,
 				23412FEA28AF795600B73D62 /* RecordDataRequest.swift in Sources */,
@@ -1524,6 +1535,7 @@
 				3C0029F1290110AE001BB6AE /* CreateWeekChallengeVM.swift in Sources */,
 				3CB9DB9C28A92528007BC1BE /* MenuBarCVC.swift in Sources */,
 				230CB2E128AD474E00B11270 /* ChallengeBlockResponseModel.swift in Sources */,
+				3CB766BB290E73B700EAE812 /* ChallengeVM.swift in Sources */,
 				237573F928FC0113006026ED /* TabView.swift in Sources */,
 				2354239428BC8BCD00865E51 /* LoginVC.swift in Sources */,
 				3C9FD39B28B64363006FA812 /* CreateChallengeListButtonView.swift in Sources */,

--- a/NEMODU/NEMODU/Global/Extension/Date+.swift
+++ b/NEMODU/NEMODU/Global/Extension/Date+.swift
@@ -38,4 +38,13 @@ extension Date {
             return weekDay - 2
         }
     }
+    
+    /// 특정 날짜의 요일을 반환(ex, 화)
+    func getDayOfWeek() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEEEE"
+        formatter.locale = Locale(identifier:"ko_KR")
+        let convertStr = formatter.string(from: self)
+        return convertStr
+    }
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/ProgressAndDoneChallengeListResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/ProgressAndDoneChallengeListResponseModel.swift
@@ -1,0 +1,17 @@
+//
+//  ProgressAndDoneChallengeListResponseModel.swift
+//  NEMODU
+//
+//  Created by Kime Heejae on 2022/10/31.
+//
+
+import Foundation
+
+struct ProgressAndDoneChallengeListElement: Codable {
+    let color, ended, name: String
+    let rank: Int
+    let started, uuid: String
+    let picturePaths: [String]
+}
+
+typealias ProgressAndDoneChallengeListResponseModel = [ProgressAndDoneChallengeListElement]

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/WaitChallengeListResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/WaitChallengeListResponseModel.swift
@@ -1,0 +1,17 @@
+//
+//  ChallengeWaitResponseModel.swift
+//  NEMODU
+//
+//  Created by Kim HeeJae on 2022/10/30.
+//
+
+import Foundation
+
+struct WaitChallengeListElement: Codable {
+    let name, uuid, started, ended: String
+    let totalCount, readyCount: Int
+    let color: String
+    let picturePaths: [String]
+}
+
+typealias WaitChallengeListResponseModel = [WaitChallengeListElement]

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeListTypeMenuBarCV.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeListTypeMenuBarCV.swift
@@ -13,15 +13,16 @@ class ChallengeListTypeMenuBarCV : ListTypeMenuBarCV {
     
     // MARK: - Variables and Properties
     
+    var challengeContainerCVC: ChallengeVC?
+    
     // MARK: - Life Cycle
     
     override func layoutSubviews() {
-        // TODO: - 리팩토링
-//        _ = menuBarCollectionView.then {
-            // 선택되어 있는 위치 지정
-//            let indexPath = IndexPath(item: challengeContainerCVC?.reloadCellIndex ?? 0, section: 0)
-//            $0.selectItem(at: indexPath, animated: false, scrollPosition: .left)
-//        }
+        // 최초 실행시 선택되어 있는 위치 지정
+        _ = menuBarCollectionView.then {
+            let indexPath = IndexPath(item: challengeContainerCVC?.reloadCellIndex ?? 0, section: 0)
+            $0.selectItem(at: indexPath, animated: false, scrollPosition: .left)
+        }
     }
     
     // MARK: - Function
@@ -34,14 +35,7 @@ extension ChallengeListTypeMenuBarCV {
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print("ChallengeType selected : ", indexPath.item)
         
-        // TODO: - 리팩토링
-        let targetItemIndex = indexPath.item
-//        let currentItemIndex = challengeContainerCVC?.reloadCellIndex ?? 0
-        
-//        challengeContainerCVC?.reloadCellIndex = targetItemIndex
-//        if targetItemIndex != currentItemIndex {
-//            challengeContainerCVC?.challengeTableView.reloadSections(IndexSet(2...2), with: targetItemIndex > currentItemIndex ? .left : .right)
-//        }
+        challengeContainerCVC?.bindChallengeList(index: indexPath.item)
     }
     
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeDoingTVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeDoingTVC.swift
@@ -19,20 +19,27 @@ class ChallengeDoingTVC : ChallengeListTVC {
     
     // MARK: - Life Cycle
     
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    override func configureView() {
+        super.configureView()
         
+        configureContentView()
     }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    override func layoutView() {
+        super.layoutView()
+        
+        configureLayout()
     }
     
     // MARK: - Function
     
-    override func configureView() {
-        super.configureView()
-        
+}
+
+// MARK: - Configure
+
+extension ChallengeDoingTVC {
+    
+    private func configureContentView() {
         _ = challengeNameImage
             .then {
                 $0.image = UIImage(named: "badge_flag")?.withRenderingMode(.alwaysTemplate)
@@ -49,9 +56,38 @@ class ChallengeDoingTVC : ChallengeListTVC {
             }
     }
     
-    override func layoutView() {
-        super.layoutView()
+    func configureChallengeDoingTVC(progressChallengeListElement: ProgressAndDoneChallengeListElement) {
+        challengeTypeLabel.text = "주간" // TODO: - 서버 response 값으로 주간, 실시간 표시 필요
         
+        let startDate = progressChallengeListElement.started.split(separator: "-")
+        let endDate = progressChallengeListElement.ended.split(separator: "-")
+        
+        let format = DateFormatter()
+        format.dateFormat = "yyyy-MM-dd"
+        
+        let dayOfWeekDate = format.date(from: progressChallengeListElement.started)
+        let dayOfWeekString = dayOfWeekDate?.getDayOfWeek()
+        
+        challengeTermLabel.text = "\(startDate[1]).\(startDate[2])(\(dayOfWeekString ?? "?") - \(endDate[1]). \(endDate[2])(일)"
+        
+        //        dDayLabel.text =  TODO: - dDay 표시
+        
+        challengeNameImage.tintColor = ChallengeColorType(rawValue: progressChallengeListElement.color)?.primaryColor
+        challengeNameLabel.text = progressChallengeListElement.name
+        
+        currentStateLabel.text = "현재순위"
+        currentJoinUserLabel.text = "\(progressChallengeListElement.rank)위"
+        
+        makeUserImageViews(numberOfUsers: progressChallengeListElement.picturePaths.count, usersImageURL: progressChallengeListElement.picturePaths)
+    }
+    
+}
+
+// MARK: - Layout
+
+extension ChallengeDoingTVC {
+    
+    private func configureLayout() {
         // remove for hide
         dDayLabel.snp.makeConstraints {
             $0.width.equalTo(0)

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeFinishTVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeFinishTVC.swift
@@ -19,20 +19,27 @@ class ChallengeFinishTVC : ChallengeListTVC {
     
     // MARK: - Life Cycle
     
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    override func configureView() {
+        super.configureView()
         
+        configureContentView()
     }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    override func layoutView() {
+        super.layoutView()
+        
+        configureLayout()
     }
     
     // MARK: - Function
     
-    override func configureView() {
-        super.configureView()
-        
+}
+
+// MARK: - Configure
+
+extension ChallengeFinishTVC {
+    
+    private func configureContentView() {
         _ = currentStateLabel
             .then {
                 $0.text = "현재 순위: -위"
@@ -43,9 +50,38 @@ class ChallengeFinishTVC : ChallengeListTVC {
             }
     }
     
-    override func layoutView() {
-        super.layoutView()
+    func configureChallengeFinishTVC(doneChallengeListElement: ProgressAndDoneChallengeListElement) {
+        challengeTypeLabel.text = "주간" // TODO: - 서버 response 값으로 주간, 실시간 표시 필요
         
+        let startDate = doneChallengeListElement.started.split(separator: "-")
+        let endDate = doneChallengeListElement.ended.split(separator: "-")
+        
+        let format = DateFormatter()
+        format.dateFormat = "yyyy-MM-dd"
+        
+        let dayOfWeekDate = format.date(from: doneChallengeListElement.started)
+        let dayOfWeekString = dayOfWeekDate?.getDayOfWeek()
+        
+        challengeTermLabel.text = "\(startDate[1]).\(startDate[2])(\(dayOfWeekString ?? "?") - \(endDate[1]). \(endDate[2])(일)"
+        
+        //        dDayLabel.text =  TODO: - dDay 표시
+        
+        challengeNameImage.tintColor = ChallengeColorType(rawValue: doneChallengeListElement.color)?.primaryColor
+        challengeNameLabel.text = doneChallengeListElement.name
+        
+        currentStateLabel.text = "현재순위"
+        currentJoinUserLabel.text = "\(doneChallengeListElement.rank)위"
+        
+        makeUserImageViews(numberOfUsers: doneChallengeListElement.picturePaths.count, usersImageURL: doneChallengeListElement.picturePaths)
+    }
+    
+}
+
+// MARK: - Layout
+
+extension ChallengeFinishTVC {
+    
+    private func configureLayout() {
         // remove for hide
         dDayLabel.snp.makeConstraints {
             $0.width.equalTo(0)

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeListTVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeListTVC.swift
@@ -15,7 +15,7 @@ class ChallengeListTVC : BaseTableViewCell {
     
     // MARK: - UI components
     
-    let contentsView = UIView()
+    private let contentsView = UIView()
         .then {
             $0.backgroundColor = .clear
             $0.layer.cornerRadius = 8
@@ -25,7 +25,7 @@ class ChallengeListTVC : BaseTableViewCell {
             $0.layer.borderWidth = 1
         }
     
-    let innerContentsView = UIView()
+    private let innerContentsView = UIView()
     
     let challengeTypeLabel = UILabel()
         .then {
@@ -82,34 +82,81 @@ class ChallengeListTVC : BaseTableViewCell {
     
     // MARK: - Life Cycle
     
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        
-        makeUserImageViews(numberOfUser: 4, userImageURL: "defaultThumbnail")
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: - Function
-    
     override func configureView() {
         super.configureView()
         
-        selectionStyle = .none
+        configureContentView()
+        
     }
     
     override func layoutView() {
         super.layoutView()
         
+        configureLayout()
+    }
+    
+    // MARK: - Function
+    
+    func makeUserImageViews(numberOfUsers: Int, usersImageURL: [String]) {
+        let userImageContainerView = UIView()
+        
+        let spacing = 12
+        for order in 1...numberOfUsers {
+            // set userImageView style
+            let userImageView = UIImageView()
+                .then {
+                    $0.layer.cornerRadius = 8
+                    $0.layer.masksToBounds = true
+                    $0.layer.borderWidth = 1
+                    $0.layer.borderColor = UIColor.white.cgColor
+                    $0.translatesAutoresizingMaskIntoConstraints = false
+                    
+                    $0.image = UIImage(named: usersImageURL[order])
+                }
+            
+            // make userImageViews contraints
+            userImageContainerView.addSubview(userImageView)
+            
+            userImageView.snp.makeConstraints {
+                $0.width.equalTo(16)
+                $0.height.equalTo(userImageView.snp.width)
+                
+                $0.verticalEdges.equalTo(userImageContainerView)
+                $0.right.equalTo(userImageContainerView.snp.right).inset((numberOfUsers - order) * spacing)
+            }
+            
+            // make userImageViews contraints to contentsView
+            innerContentsView.addSubview(userImageContainerView)
+            
+            userImageContainerView.snp.makeConstraints {
+                $0.centerY.equalTo(currentStateLabel)
+                $0.right.equalTo(dDayLabel.snp.right)
+            }
+        }
+    }
+    
+}
+
+// MARK: - Configure
+
+extension ChallengeListTVC {
+    
+    private func configureContentView() {
+        selectionStyle = .none
+    }
+    
+}
+
+// MARK: - Layout
+
+extension ChallengeListTVC {
+    
+    private func configureLayout() {
         contentView.addSubview(contentsView)
         contentsView.addSubview(innerContentsView)
-        
-        innerContentsView.addSubviews([challengeTypeLabel, challengeTermLabel, dDayLabel])
-        innerContentsView.addSubviews([challengeNameImage, challengeNameLabel])
-        innerContentsView.addSubviews([currentStateLabel, currentJoinUserLabel])
-        
+        innerContentsView.addSubviews([challengeTypeLabel, challengeTermLabel, dDayLabel,
+                                       challengeNameImage, challengeNameLabel,
+                                       currentStateLabel, currentJoinUserLabel])
         
         
         let padding1 = 12
@@ -168,42 +215,4 @@ class ChallengeListTVC : BaseTableViewCell {
         }
     }
     
-    func makeUserImageViews(numberOfUser: Int, userImageURL: String) {
-        let userImageContainerView = UIView()
-        
-        let spacing = 12
-        for order in 1...numberOfUser {
-            // set userImageView style
-            let userImageView = UIImageView()
-                .then {
-                    $0.layer.cornerRadius = 8
-                    $0.layer.masksToBounds = true
-                    $0.layer.borderWidth = 1
-                    $0.layer.borderColor = UIColor.white.cgColor
-                    $0.translatesAutoresizingMaskIntoConstraints = false
-                    
-                    $0.image = UIImage(named: userImageURL)
-                }
-            
-            // make userImageViews contraints
-            userImageContainerView.addSubview(userImageView)
-            
-            userImageView.snp.makeConstraints {
-                $0.width.equalTo(16)
-                $0.height.equalTo(userImageView.snp.width)
-                
-                $0.verticalEdges.equalTo(userImageContainerView)
-                $0.right.equalTo(userImageContainerView.snp.right).inset((numberOfUser - order) * spacing)
-            }
-            
-            // make userImageViews contraints to contentsView
-            innerContentsView.addSubview(userImageContainerView)
-            
-            userImageContainerView.snp.makeConstraints {
-                $0.centerY.equalTo(currentStateLabel)
-                $0.right.equalTo(dDayLabel.snp.right)
-            }
-        }
-        
-    }
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeWaitingTVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeWaitingTVC.swift
@@ -19,44 +19,39 @@ class ChallengeWaitingTVC : ChallengeListTVC {
     
     // MARK: - Life Cycle
     
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
     // MARK: - Function
     
-    override func configureView() {
-        super.configureView()
-        
-        _ = dDayLabel
-            .then {
-                $0.text = ($0.text ?? "D-") + ""
-            }
-        
-        _ = challengeNameImage
-            .then {
-                $0.image = UIImage(named: "badge_flag")?.withRenderingMode(.alwaysTemplate)
-                $0.tintColor = ChallengeColorType(rawValue: "Red")?.primaryColor
-            }
-        
-        _ = currentStateLabel
-            .then {
-                $0.text = "----"
-            }
-        _ = currentJoinUserLabel
-            .then {
-                $0.text = "-/-"
-            }
-    }
+}
+
+// MARK: - Configure
+
+extension ChallengeWaitingTVC {
     
-    override func layoutView() {
-        super.layoutView()
+    func configureChallengeWaitTVC(waitChallengeListElement: WaitChallengeListElement) {
+        challengeTypeLabel.text = "주간" // TODO: - 서버 response 값으로 주간, 실시간 표시 필요
         
+        let startDate = waitChallengeListElement.started.split(separator: "-")
+        let endDate = waitChallengeListElement.ended.split(separator: "-")
+        
+        let format = DateFormatter()
+        format.dateFormat = "yyyy-MM-dd"
+        
+        let dayOfWeekDate = format.date(from: waitChallengeListElement.started)
+        let dayOfWeekString = dayOfWeekDate?.getDayOfWeek()
+        
+        challengeTermLabel.text = "\(startDate[1]).\(startDate[2])(\(dayOfWeekString ?? "?") - \(endDate[1]). \(endDate[2])(일)"
+        
+        //        dDayLabel.text =  TODO: - dDay 표시
+        
+        challengeNameImage.tintColor = ChallengeColorType(rawValue: waitChallengeListElement.color)?.primaryColor
+        challengeNameLabel.text = waitChallengeListElement.name
+        
+        let readyCount = waitChallengeListElement.readyCount
+        let totalCount = waitChallengeListElement.totalCount
+        currentStateLabel.text = readyCount == totalCount ? "모집완료" : "대기중"
+        currentJoinUserLabel.text = "\(readyCount)/\(totalCount)"
+        
+        makeUserImageViews(numberOfUsers: readyCount, usersImageURL: waitChallengeListElement.picturePaths)
     }
     
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/HV/ChallengeListTVHV.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/HV/ChallengeListTVHV.swift
@@ -24,15 +24,9 @@ class ChallengeListTVHV : ChallengeTitleTVHV {
     
     // MARK: - Variables and Properties
     
+    var challengeContainerCVC: ChallengeVC?
+    
     // MARK: - Life Cycle
-    
-    override init(reuseIdentifier: String?) {
-        super.init(reuseIdentifier: reuseIdentifier)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
     
     // MARK: - Function
     

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/ChallengeRankingVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/ChallengeRankingVC.swift
@@ -21,12 +21,12 @@ class ChallengeRankingVC: BaseViewController {
         }
     
     private let baseScrollView = UIScrollView()
-    .then {
-        $0.isPagingEnabled = true
-        
-        $0.showsHorizontalScrollIndicator = false
-        $0.isScrollEnabled = false
-    }
+        .then {
+            $0.isPagingEnabled = true
+            
+            $0.showsHorizontalScrollIndicator = false
+            $0.isScrollEnabled = false
+        }
     private let baseStackView = UIStackView()
         .then {
             $0.spacing = 0

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/RankingListVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/RankingListVC.swift
@@ -77,7 +77,7 @@ class RankingListVC : BaseViewController {
     override func layoutView() {
         super.layoutView()
         
-        configreLayout()
+        configureLayout()
     }
     
     override func bindInput() {
@@ -134,7 +134,7 @@ class RankingListVC : BaseViewController {
 
 extension RankingListVC {
     
-    private func configreLayout() {
+    private func configureLayout() {
         view.addSubviews([
                                  weeksNavigationView,
                                  myRankingTVC,

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/RankingVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/RankingVC.swift
@@ -21,12 +21,12 @@ class RankingVC : BaseViewController {
         }
     
     private let baseScrollView = UIScrollView()
-    .then {
-        $0.isPagingEnabled = true
-        
-        $0.showsHorizontalScrollIndicator = false
-        $0.isScrollEnabled = false
-    }
+        .then {
+            $0.isPagingEnabled = true
+            
+            $0.showsHorizontalScrollIndicator = false
+            $0.isScrollEnabled = false
+        }
     private let baseStackView = UIStackView()
         .then {
             $0.spacing = 0

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewModel/Challenge/ChallengeVM.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewModel/Challenge/ChallengeVM.swift
@@ -1,0 +1,121 @@
+//
+//  ChallengeVM.swift
+//  NEMODU
+//
+//  Created by Kim HeeJae on 2022/10/30.
+//
+
+import Foundation
+import RxCocoa
+import RxSwift
+
+protocol ChallengeViewModelOuput: Lodable {
+//    var areaRankings: PublishRelay<AreaRankingListResponseModel> { get }
+}
+
+final class ChallengeVM: BaseViewModel {
+    var apiSession: APIService = APISession()
+    let apiError = PublishSubject<APIError>()
+    
+    var bag = DisposeBag()
+    
+    var input = Input()
+    var output = Output()
+    
+    // MARK: - Input
+    
+    struct Input {}
+    
+    // MARK: - Output
+    
+    struct Output: ChallengeViewModelOuput {
+        var loading = BehaviorRelay<Bool>(value: false)
+        var waitChallengeList = PublishRelay<WaitChallengeListResponseModel>()
+        var progressChallengeList = PublishRelay<ProgressAndDoneChallengeListResponseModel>()
+        var doneChallengeList = PublishRelay<ProgressAndDoneChallengeListResponseModel>()
+    }
+    
+    // MARK: - Init
+    
+    init() {
+        bindInput()
+        bindOutput()
+    }
+    
+    deinit {
+        bag = DisposeBag()
+    }
+}
+
+// MARK: - Input
+
+extension ChallengeVM: Input {
+    func bindInput() {}
+}
+
+// MARK: - Output
+
+extension ChallengeVM: Output {
+    func bindOutput() {}
+}
+
+// MARK: - Networking
+
+extension ChallengeVM {
+    func getWaitChallengeList() {
+        guard let nickname = UserDefaults.standard.string(forKey: UserDefaults.Keys.nickname) else { return }
+        let path = "challenge​/wait?nickname=\(nickname)"
+        let resource = urlResource<WaitChallengeListResponseModel>(path: path)
+        
+        apiSession.getRequest(with: resource)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                
+                switch result {
+                case .failure(let error):
+                    owner.apiError.onNext(error)
+                case .success(let data):
+                    owner.output.waitChallengeList.accept(data)
+                }
+            })
+            .disposed(by: bag)
+    }
+    
+    func getProgressChallengeList() {
+        guard let nickname = UserDefaults.standard.string(forKey: UserDefaults.Keys.nickname) else { return }
+        let path = "challenge/progress?nickname=\(nickname)"
+        let resource = urlResource<ProgressAndDoneChallengeListResponseModel>(path: path)
+        
+        apiSession.getRequest(with: resource)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                
+                switch result {
+                case .failure(let error):
+                    owner.apiError.onError(error)
+                case .success(let data):
+                    owner.output.progressChallengeList.accept(data)
+                }
+            })
+            .disposed(by: bag)
+    }
+    
+    func getDoneChallengeList() {
+        guard let nickname = UserDefaults.standard.string(forKey: UserDefaults.Keys.nickname) else { return }
+        let path = "challenge/done?nickname=\(nickname)"
+        let resource = urlResource<ProgressAndDoneChallengeListResponseModel>(path: path)
+        
+        apiSession.getRequest(with: resource)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                
+                switch result {
+                case .failure(let error):
+                    owner.apiError.onError(error)
+                case .success(let data):
+                    owner.output.doneChallengeList.accept(data)
+                }
+            })
+            .disposed(by: bag)
+    }
+}


### PR DESCRIPTION
## PR 요약
- 챌린지 목록 리팩토링
- 챌린지 목록 서버연결

## 변경 사항
- Date extension에 특정날짜의 요일 반환 함수 정의

## 특이 사항
- baseScrollView와 baseStackView를 이용하여 챌린지 목록 구현을 개선하려 그랬으나 아무래도 어려운것 같아 우선 기존 방식에서 리팩토링과 서버연결을 구현하였습니다. 서버코드 구조와 관련하여 챌린지 화면에 있는 초대받은 챌린지, 챌린지 목록 3개(진행 대기중, 진행중, 진행완료) 는 우선 ChallengeVM에서 관리될 예정입니다

#### Linked Issue
close #80

