### PR TITLE
[FIX] 초대받은 챌린지 수락 파라미터 대응

### DIFF
--- a/NEMODU/NEMODU/Global/Enum/InvitedChallengeAcceptType.swift
+++ b/NEMODU/NEMODU/Global/Enum/InvitedChallengeAcceptType.swift
@@ -11,7 +11,7 @@ import UIKit
 enum InvitedChallengeAcceptType: String {
     case master
     case wait
-    case progress
+    case ready
     case reject
 }
 
@@ -22,7 +22,7 @@ extension InvitedChallengeAcceptType {
             return "주최자"
         case .wait:
             return "대기중"
-        case .progress:
+        case .ready:
             return "수락 완료"
         case .reject:
             return "거절"
@@ -31,7 +31,7 @@ extension InvitedChallengeAcceptType {
     
     var statusColor: UIColor {
         switch self {
-        case .progress:
+        case .ready:
             return .main
         default:
             return .gray600

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/HV/InvitedChallengeDetailTVHV.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/HV/InvitedChallengeDetailTVHV.swift
@@ -103,7 +103,7 @@ class InvitedChallengeDetailTVHV : ChallengeDetailTVHV {
         for info in infos {
             if info.nickname == myUserNickname {
                 switch info.status {
-                case InvitedChallengeAcceptType.progress.description:
+                case InvitedChallengeAcceptType.ready.description:
                     rejectButton.isHidden = true
                     acceptButton.isHidden = true
                     


### PR DESCRIPTION
## PR 요약
초대받은 챌린지 수락유무 파라미터 값 변경(수락 완료: PROGRESS -> READY)

## 변경 사항

##  ScreenShot

#### Linked Issue
close #146

