### PR TITLE
Bug/#166 etc bugs

### DIFF
--- a/NEMODU/NEMODU.xcodeproj/project.pbxproj
+++ b/NEMODU/NEMODU.xcodeproj/project.pbxproj
@@ -1949,8 +1949,9 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1983,8 +1984,9 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/NEMODU/NEMODU.xcodeproj/project.pbxproj
+++ b/NEMODU/NEMODU.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		2348B4122892D901001095BC /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2348B4112892D901001095BC /* LoadingView.swift */; };
 		2348B41E2892DF0D001095BC /* MypageVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2348B41D2892DF0D001095BC /* MypageVC.swift */; };
 		2348B4252892E007001095BC /* NEMODUTBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2348B4242892E007001095BC /* NEMODUTBC.swift */; };
+		2352A29C2A0FAAD600CA072B /* MainNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2352A29B2A0FAAD600CA072B /* MainNC.swift */; };
 		2354239128BBA54000865E51 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2354239028BBA54000865E51 /* UserDefaults+.swift */; };
 		2354239428BC8BCD00865E51 /* LoginVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2354239328BC8BCD00865E51 /* LoginVC.swift */; };
 		2359B08C28EC724000930EF0 /* DateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2359B08B28EC724000930EF0 /* DateType.swift */; };
@@ -346,6 +347,7 @@
 		2348B4182892DEED001095BC /* ChallengeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeVC.swift; sourceTree = "<group>"; };
 		2348B41D2892DF0D001095BC /* MypageVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageVC.swift; sourceTree = "<group>"; };
 		2348B4242892E007001095BC /* NEMODUTBC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEMODUTBC.swift; sourceTree = "<group>"; };
+		2352A29B2A0FAAD600CA072B /* MainNC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNC.swift; sourceTree = "<group>"; };
 		2354239028BBA54000865E51 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		2354239328BC8BCD00865E51 /* LoginVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVC.swift; sourceTree = "<group>"; };
 		2359B08B28EC724000930EF0 /* DateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateType.swift; sourceTree = "<group>"; };
@@ -803,6 +805,7 @@
 			isa = PBXGroup;
 			children = (
 				2348B3DC2892CF92001095BC /* MapVC.swift */,
+				2352A29B2A0FAAD600CA072B /* MainNC.swift */,
 				23B7206A28A12BCD00D3A410 /* MainVC.swift */,
 				23B7206C28A12BE800D3A410 /* WalkingVC.swift */,
 				23412FEF28AFB74800B73D62 /* RecordResultNC.swift */,
@@ -1674,6 +1677,7 @@
 				3CC1EC7528D06917007C87F6 /* CreateAccumulateChallengeVC.swift in Sources */,
 				23412FDC28AE375D00B73D62 /* ChallengeElementResponseModel.swift in Sources */,
 				3C2327B92A0387EA00251316 /* NotificationListTVC.swift in Sources */,
+				2352A29C2A0FAAD600CA072B /* MainNC.swift in Sources */,
 				3C6F03152910B471002829D7 /* InvitedFriendsTVC.swift in Sources */,
 				23412FF028AFB74800B73D62 /* RecordResultNC.swift in Sources */,
 				2375740128FC3824006026ED /* NicknameSearchBar.swift in Sources */,

--- a/NEMODU/NEMODU/Global/Class/BaseViewController.swift
+++ b/NEMODU/NEMODU/Global/Class/BaseViewController.swift
@@ -60,4 +60,9 @@ class BaseViewController: UIViewController {
         guard let ad = UIApplication.shared.delegate as? AppDelegate else { return }
         ad.window?.rootViewController = LoginNC()
     }
+    
+    /// 제스쳐로 뒤로가기 인터랙션 Enabled 상태를 지정하는 메서드
+    func setInteractivePopGesture(_ isEnabled: Bool) {
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = isEnabled
+    }
 }

--- a/NEMODU/NEMODU/Global/Enum/AlertType.swift
+++ b/NEMODU/NEMODU/Global/Enum/AlertType.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum AlertType {
-    case requestAuthority
+    case requestLocationAuthority
     case recordNetworkError
     case defaultNetworkError
     case minimumBlocks
@@ -22,7 +22,7 @@ enum AlertType {
 extension AlertType {
     var alertTitle: String {
         switch self {
-        case .requestAuthority:
+        case .requestLocationAuthority:
             return "위치 정보 접근을 허용해주세요!"
         case .recordNetworkError:
             return "네트워크 오류로 인해\n기록이 저장되지 않았습니다.\n\n다시 시도해볼까요?"
@@ -45,7 +45,7 @@ extension AlertType {
     
     var alertMessage: String? {
         switch self {
-        case .requestAuthority:
+        case .requestLocationAuthority:
             return "회원님의 위치 정보는\n활동 기록 및 측정에 사용됩니다.\n\n정보는 친구들에게만 보여지며\n설정에서 언제든 공유를 중지할 수 있습니다."
         case .recordNetworkError:
             return nil
@@ -68,7 +68,7 @@ extension AlertType {
     
     var highlightBtnTitle: String {
         switch self {
-        case .requestAuthority:
+        case .requestLocationAuthority:
             return "시스템 설정 가기"
         case .recordNetworkError:
             return "다시 저장하기"
@@ -81,7 +81,7 @@ extension AlertType {
     
     var normalBtnTitle: String? {
         switch self {
-        case .requestAuthority:
+        case .requestLocationAuthority:
             return "다음에"
         case .recordNetworkError:
             return "그냥 나가기"

--- a/NEMODU/NEMODU/Global/Enum/AlertType.swift
+++ b/NEMODU/NEMODU/Global/Enum/AlertType.swift
@@ -17,7 +17,7 @@ enum AlertType {
     case realTimeChallenge
     case createWeekChallenge
     case sendMailError
-    case profileEdited
+    case discardChanges
 }
 
 extension AlertType {
@@ -41,8 +41,8 @@ extension AlertType {
             return "주간 챌린지 생성 실패"
         case .sendMailError:
             return "메일(Mail) 앱을 열 수 없습니다"
-        case .profileEdited:
-            return "프로필 편집 나가기"
+        case .discardChanges:
+            return "지금 나가시겠습니까?\n변경사항이 저장되지 않습니다."
         }
     }
     
@@ -52,7 +52,7 @@ extension AlertType {
             return "회원님의 위치 정보는\n활동 기록 및 측정에 사용됩니다.\n\n정보는 친구들에게만 보여지며\n설정에서 언제든 공유를 중지할 수 있습니다."
         case .requestMotionAuthority:
             return "회원님의 피트니스 정보는\n걸음수 기록 및 측정에 사용됩니다.\n\n해당 정보는 보다 정확한\n기록 측정을 위해 사용됩니다.\n설정에서 언제든 공유를 중지할 수 있습니다."
-        case .recordNetworkError:
+        case .recordNetworkError, .discardChanges:
             return nil
         case .defaultNetworkError:
             return "네트워크가 원활하지 않아 접속이 지연되고\n있습니다. 잠시 후에 다시 시도해 주세요."
@@ -66,8 +66,6 @@ extension AlertType {
             return "생성에 오류가 발생하였습니다"
         case .sendMailError:
             return "아래 주소를 통해 문의하실 수 있습니다\n📨 nemodu.official@gmail.com"
-        case .profileEdited:
-            return "화면을 나가면 변경사항은 저장되지 않습니다. 나가시겠습니까?"
         }
     }
     
@@ -77,10 +75,12 @@ extension AlertType {
             return "시스템 설정 가기"
         case .recordNetworkError:
             return "다시 저장하기"
-        case .defaultNetworkError, .realTimeChallenge, .createWeekChallenge, .sendMailError, .profileEdited:
+        case .defaultNetworkError, .realTimeChallenge, .createWeekChallenge, .sendMailError:
             return "확인"
         case .minimumBlocks, .speedWarning:
             return "계속 하기"
+        case .discardChanges:
+            return "나가기"
         }
     }
     
@@ -94,8 +94,8 @@ extension AlertType {
             return nil
         case .minimumBlocks, .speedWarning:
             return "기록 끝내기"
-        case .profileEdited:
-            return "취소"
+        case .discardChanges:
+            return "계속 작성하기"
         }
     }
 }

--- a/NEMODU/NEMODU/Global/Enum/AlertType.swift
+++ b/NEMODU/NEMODU/Global/Enum/AlertType.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum AlertType {
     case requestLocationAuthority
+    case requestMotionAuthority
     case recordNetworkError
     case defaultNetworkError
     case minimumBlocks
@@ -24,6 +25,8 @@ extension AlertType {
         switch self {
         case .requestLocationAuthority:
             return "위치 정보 접근을 허용해주세요!"
+        case .requestMotionAuthority:
+            return "동작 및 피트니스 활동\n접근을 허용해주세요!"
         case .recordNetworkError:
             return "네트워크 오류로 인해\n기록이 저장되지 않았습니다.\n\n다시 시도해볼까요?"
         case .defaultNetworkError:
@@ -47,6 +50,8 @@ extension AlertType {
         switch self {
         case .requestLocationAuthority:
             return "회원님의 위치 정보는\n활동 기록 및 측정에 사용됩니다.\n\n정보는 친구들에게만 보여지며\n설정에서 언제든 공유를 중지할 수 있습니다."
+        case .requestMotionAuthority:
+            return "회원님의 피트니스 정보는\n걸음수 기록 및 측정에 사용됩니다.\n\n해당 정보는 보다 정확한\n기록 측정을 위해 사용됩니다.\n설정에서 언제든 공유를 중지할 수 있습니다."
         case .recordNetworkError:
             return nil
         case .defaultNetworkError:
@@ -68,7 +73,7 @@ extension AlertType {
     
     var highlightBtnTitle: String {
         switch self {
-        case .requestLocationAuthority:
+        case .requestLocationAuthority, .requestMotionAuthority:
             return "시스템 설정 가기"
         case .recordNetworkError:
             return "다시 저장하기"
@@ -81,11 +86,11 @@ extension AlertType {
     
     var normalBtnTitle: String? {
         switch self {
-        case .requestLocationAuthority:
+        case .requestMotionAuthority:
             return "다음에"
         case .recordNetworkError:
             return "그냥 나가기"
-        case .defaultNetworkError, .realTimeChallenge, .createWeekChallenge, .sendMailError:
+        case .requestLocationAuthority, .defaultNetworkError, .realTimeChallenge, .createWeekChallenge, .sendMailError:
             return nil
         case .minimumBlocks, .speedWarning:
             return "기록 끝내기"

--- a/NEMODU/NEMODU/Global/Enum/FriendStatusType.swift
+++ b/NEMODU/NEMODU/Global/Enum/FriendStatusType.swift
@@ -10,8 +10,8 @@ import UIKit
 enum FriendStatusType: String {
     case accept = "ACCEPT" // 친구중
     case requesting = "REQUESTING" // 친구 요청중
-    case responseWait = "RESPONSEWAIT" // 수락 대기중
-    case noFriend = "NOFRIEND" // 친구 아님
+    case responseWait = "RESPONSE_WAIT" // 수락 대기중
+    case noFriend = "NO_FRIEND" // 친구 아님
 }
 
 extension FriendStatusType {

--- a/NEMODU/NEMODU/Global/Enum/ToastType.swift
+++ b/NEMODU/NEMODU/Global/Enum/ToastType.swift
@@ -13,6 +13,7 @@ enum ToastType {
     case friendDeleted
     case profileChanged
     case networkError
+    case saveCompleted
 }
 
 extension ToastType {
@@ -28,6 +29,8 @@ extension ToastType {
             return "프로필이 변경 되었습니다."
         case .networkError:
             return "연결이 좋지 않습니다. 네트워크 연결을 확인해주세요."
+        case .saveCompleted:
+            return "저장이 완료되었습니다."
         }
     }
 }

--- a/NEMODU/NEMODU/Global/Extension/UIApplication+.swift
+++ b/NEMODU/NEMODU/Global/Extension/UIApplication+.swift
@@ -8,8 +8,13 @@
 import UIKit
 
 extension UIApplication {
+    /// deprecated keyWindow를 대체
+    var window: UIWindow? {
+        UIApplication.shared.connectedScenes.map({ $0 as? UIWindowScene }).compactMap({ $0 }).first?.keyWindow
+    }
+    
     /// 최상위 viewController를 반환
-    class func topViewController(base: UIViewController? = UIApplication.shared.connectedScenes.map({ $0 as? UIWindowScene }).compactMap({ $0 }).first?.windows.first?.rootViewController) -> UIViewController? {
+    class func topViewController(base: UIViewController? = UIApplication.shared.window?.rootViewController) -> UIViewController? {
         if let nav = base as? UINavigationController {
             return topViewController(base: nav.visibleViewController)
         }

--- a/NEMODU/NEMODU/Global/Extension/UIViewController+.swift
+++ b/NEMODU/NEMODU/Global/Extension/UIViewController+.swift
@@ -49,6 +49,12 @@ extension UIViewController {
         dismiss(animated: false)
     }
     
+    /// 설정 앱 열기
+    @objc func openSystem() {
+        dismissAlert()
+        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+    }
+    
     /// 알람창을 닫고 viewController를 pop시키는 메서드
     @objc func dismissAlertAndPopVC() {
         dismissAlert()

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
@@ -47,20 +47,10 @@ class CreateWeekChallengeVC: CreateChallengeVC {
             $0.font = .body1
             $0.textColor = .gray900
         }
-    private let insertChallengeNameTextField = UITextField()
+    private let insertChallengeNameTextField = NemoduTextField()
         .then {
-            $0.attributedPlaceholder = NSAttributedString(string: "챌린지 이름을 작성해주세요.",
-                                                          attributes: [NSAttributedString.Key.foregroundColor : UIColor.gray600,
-                                                                       NSAttributedString.Key.font: UIFont.caption1])
-            $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 0))
-            $0.leftViewMode = .always
-            
-            $0.tintColor = .main
-            $0.backgroundColor = .gray50
-            
-            $0.layer.cornerRadius = 8
-            $0.layer.borderWidth = 1
-            $0.layer.borderColor = UIColor.clear.cgColor
+            $0.placeholder = "챌린지 이름을 작성해주세요"
+            $0.returnKeyType = .done
         }
     private let limitedAlertChallengeNameCountImageView = UIImageView()
         .then {
@@ -158,6 +148,7 @@ class CreateWeekChallengeVC: CreateChallengeVC {
         
         configureNavigationBar()
         configureConfirmButton()
+        configureTextField()
     }
     
     override func layoutView() {
@@ -316,6 +307,10 @@ extension CreateWeekChallengeVC {
             }
     }
     
+    /// 챌린지 이름을 입력하는 텍스트필드의 완료 버튼의 delegate를 연결하는 메서드
+    private func configureTextField() {
+        insertChallengeNameTextField.delegate = self
+    }
 }
 
 // MARK: - Layout
@@ -357,7 +352,7 @@ extension CreateWeekChallengeVC {
             $0.horizontalEdges.equalTo(insertChallengeNameView).inset(16)
         }
         insertChallengeNameTextField.snp.makeConstraints {
-            $0.height.equalTo(38)
+            $0.height.equalTo(42)
 
             $0.top.equalTo(insertChallengeNameLabel.snp.bottom).offset(18.5)
             $0.horizontalEdges.equalTo(insertChallengeNameLabel)
@@ -536,5 +531,14 @@ extension CreateWeekChallengeVC {
                 self.present(createChallengeSuccuessVC, animated: true)
             })
             .disposed(by: bag)
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension CreateWeekChallengeVC: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
     }
 }

--- a/NEMODU/NEMODU/Screen/Login/Model/UserDataModel.swift
+++ b/NEMODU/NEMODU/Screen/Login/Model/UserDataModel.swift
@@ -27,6 +27,7 @@ extension UserDataModel {
         }
         
         var parameter: Parameters = [
+            "deviceType": UIDevice.current.model.contains("iPhone") ? "PHONE" : "PAD",
             "nickname": nickname,
             "email": email,
             "friends": friends,

--- a/NEMODU/NEMODU/Screen/Login/ViewController/AddFriendsVC.swift
+++ b/NEMODU/NEMODU/Screen/Login/ViewController/AddFriendsVC.swift
@@ -47,6 +47,7 @@ class AddFriendsVC: BaseViewController {
     private let friendsTV = UITableView(frame: .zero)
         .then {
             $0.separatorStyle = .none
+            $0.rowHeight = 64
         }
     
     override func viewDidLoad() {
@@ -84,7 +85,6 @@ extension AddFriendsVC {
                           friendsTV])
         
         friendsTV.register(AddFriendTVC.self, forCellReuseIdentifier: AddFriendTVC.className)
-        friendsTV.delegate = self
     }
 }
 
@@ -132,12 +132,4 @@ extension AddFriendsVC {
 
 extension AddFriendsVC {
     
-}
-
-// MARK: - UITableViewDelegate
-
-extension AddFriendsVC: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        64.0
-    }
 }

--- a/NEMODU/NEMODU/Screen/Login/ViewController/EnterVC.swift
+++ b/NEMODU/NEMODU/Screen/Login/ViewController/EnterVC.swift
@@ -72,6 +72,16 @@ class EnterVC: BaseViewController {
         changeRootVC()
     }
     
+    override func bindLoading() {
+        super.bindLoading()
+        viewModel.output.loading
+            .asDriver()
+            .drive(onNext: { [weak self] isLoading in
+                guard let self = self else { return }
+                self.loading(loading: isLoading)
+            })
+            .disposed(by: bag)
+    }
 }
 
 // MARK: - Configure

--- a/NEMODU/NEMODU/Screen/Login/ViewController/LocationSettingVC.swift
+++ b/NEMODU/NEMODU/Screen/Login/ViewController/LocationSettingVC.swift
@@ -117,9 +117,11 @@ extension LocationSettingVC {
             $0.centerY.equalTo(subTitleLabel.snp.centerY)
         }
         
+        let imageViewRatio = (exampleImageView.image?.size.height ?? 1) / (exampleImageView.image?.size.width ?? 1)
         exampleImageView.snp.makeConstraints {
             $0.top.equalTo(subTitleLabel.snp.bottom).offset(52)
             $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(exampleImageView.snp.width).multipliedBy(imageViewRatio)
         }
     }
 }

--- a/NEMODU/NEMODU/Screen/Login/ViewModel/EnterVM.swift
+++ b/NEMODU/NEMODU/Screen/Login/ViewModel/EnterVM.swift
@@ -22,7 +22,8 @@ final class EnterVM: BaseViewModel {
     
     // MARK: - Output
     
-    struct Output {
+    struct Output: Lodable {
+        var loading = BehaviorRelay<Bool>(value: false)
         var isLoginSuccess = PublishRelay<Bool>()
     }
     
@@ -57,6 +58,7 @@ extension EnterVM {
         let path = "auth/sign"
         let resource = urlResource<NicknameModel>(path: path)
         
+        output.beginLoading()
         AuthAPI.shared.signupRequest(with: resource, param: userData.userDataParam)
             .withUnretained(self)
             .subscribe(onNext: { owner, result in
@@ -67,6 +69,7 @@ extension EnterVM {
                     UserDefaults.standard.set(data.nickname, forKey: UserDefaults.Keys.nickname)
                     owner.output.isLoginSuccess.accept(true)
                 }
+                owner.output.endLoading()
             })
             .disposed(by: bag)
     }

--- a/NEMODU/NEMODU/Screen/Map/Cell/TVC/ProceedingChallengeTVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/Cell/TVC/ProceedingChallengeTVC.swift
@@ -35,6 +35,8 @@ class ProceedingChallengeTVC: UITableViewCell {
             $0.tintColor = .gray300
         }
     
+    var challengeUUID: String?
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         configureView()
@@ -52,6 +54,7 @@ class ProceedingChallengeTVC: UITableViewCell {
         challengeIcon.image = nil
         challengeTitle.text = nil
         challengeSubtitle.text = nil
+        challengeUUID = nil
     }
 }
 
@@ -90,6 +93,7 @@ extension ProceedingChallengeTVC {
     func configureCell(with element: ChallengeElementResponseModel, isMyList: Bool = false) {
         challengeIcon.tintColor = ChallengeColorType(rawValue: element.color)?.primaryColor ?? .gray500
         challengeTitle.text = element.name
+        challengeUUID = element.uuid
         
         if let rank = element.rank {
             challengeSubtitle.text = isMyList

--- a/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
@@ -55,7 +55,7 @@ class ChallengeListBottomSheet: DynamicBottomSheetViewController {
     
     private let viewModel = ChallengeListVM()
     private let bag = DisposeBag()
-    weak var delegate: PushCreateChallengeVC?
+    weak var delegate: PushChallengeVC?
     
     // constants
     private let cellHeight = 69
@@ -145,7 +145,7 @@ extension ChallengeListBottomSheet {
             .drive(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 self.dismiss(animated: true) {
-                    self.delegate?.switchTabToChallengeAndPushCreateChallengeVC()
+                    self.delegate?.pushCreateChallengeVC()
                 }
             })
             .disposed(by: bag)
@@ -204,6 +204,6 @@ extension ChallengeListBottomSheet: UITableViewDelegate {
 
 // MARK: - Protocol
 
-protocol PushCreateChallengeVC: AnyObject {
-    func switchTabToChallengeAndPushCreateChallengeVC()
+protocol PushChallengeVC: AnyObject {
+    func pushCreateChallengeVC()
 }

--- a/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
@@ -199,6 +199,14 @@ extension ChallengeListBottomSheet: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        
+        guard let cell = tableView.cellForRow(at: indexPath) as? ProceedingChallengeTVC,
+              let uuid = cell.challengeUUID
+        else { return }
+        
+        dismiss(animated: true) {
+            self.delegate?.pushChallengeDetail(uuid)
+        }
     }
 }
 
@@ -206,4 +214,6 @@ extension ChallengeListBottomSheet: UITableViewDelegate {
 
 protocol PushChallengeVC: AnyObject {
     func pushCreateChallengeVC()
+    
+    func pushChallengeDetail(_ uuid: String)
 }

--- a/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
@@ -56,6 +56,10 @@ class ChallengeListBottomSheet: DynamicBottomSheetViewController {
     private let viewModel = ChallengeListVM()
     private let bag = DisposeBag()
     
+    // constants
+    private let cellHeight = 69
+    private let emptyViewHeight = 304
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         viewModel.getProceedingChallengeList()
@@ -75,11 +79,6 @@ extension ChallengeListBottomSheet {
         contentView.addSubviews([viewBar,
                                  sheetTitle])
         
-        // bottomSheet height
-        contentView.snp.makeConstraints {
-            $0.height.equalTo(304)
-        }
-        
         viewBar.snp.makeConstraints {
             $0.width.equalTo(32)
             $0.height.equalTo(4)
@@ -93,12 +92,18 @@ extension ChallengeListBottomSheet {
         }
     }
     
-    private func configureChallengeListTV() {
+    /// 챌린지 개수에 따라 화면 구현
+    private func configureChallengeListTV(_ challengeCnt: Int) {
         contentView.addSubview(proceedingChallengeTV)
         
         proceedingChallengeTV.register(ProceedingChallengeTVC.self,
                                        forCellReuseIdentifier: ProceedingChallengeTVC.className)
         proceedingChallengeTV.delegate = self
+        
+        // Layout
+        contentView.snp.makeConstraints {
+            $0.height.equalTo(challengeCnt * cellHeight + 55 + Int(UIApplication.shared.window?.safeAreaInsets.bottom ?? 0))
+        }
         
         proceedingChallengeTV.snp.makeConstraints {
             $0.top.equalTo(sheetTitle.snp.bottom).offset(12)
@@ -107,9 +112,14 @@ extension ChallengeListBottomSheet {
         }
     }
     
+    /// 챌린지가 존재하지 않을 때의 화면
     private func configureNoneData() {
         contentView.addSubviews([noneMessage,
                                  makeChallengeBtn])
+        
+        contentView.snp.makeConstraints {
+            $0.height.equalTo(emptyViewHeight)
+        }
         
         noneMessage.snp.makeConstraints {
             $0.centerX.equalToSuperview()
@@ -137,7 +147,7 @@ extension ChallengeListBottomSheet {
             .subscribe(onNext: { owner, item in
                 item.count == 0
                 ? owner.configureNoneData()
-                : owner.configureChallengeListTV()
+                : owner.configureChallengeListTV(item.count)
                 owner.proceedingChallengeTV.reloadData()
             })
             .disposed(by: bag)
@@ -167,7 +177,7 @@ extension ChallengeListBottomSheet {
 
 extension ChallengeListBottomSheet: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        69.0
+        CGFloat(cellHeight)
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
@@ -55,6 +55,7 @@ class ChallengeListBottomSheet: DynamicBottomSheetViewController {
     
     private let viewModel = ChallengeListVM()
     private let bag = DisposeBag()
+    weak var delegate: PushCreateChallengeVC?
     
     // constants
     private let cellHeight = 69
@@ -69,6 +70,7 @@ class ChallengeListBottomSheet: DynamicBottomSheetViewController {
         super.configureView()
         configureBottomSheet()
         bindTableView()
+        bindMakeChallengeBtn()
     }
 }
 
@@ -135,6 +137,21 @@ extension ChallengeListBottomSheet {
     }
 }
 
+// MARK: - Input
+extension ChallengeListBottomSheet {
+    func bindMakeChallengeBtn() {
+        makeChallengeBtn.rx.tap
+            .asDriver()
+            .drive(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.dismiss(animated: true) {
+                    self.delegate?.switchTabToChallengeAndPushCreateChallengeVC()
+                }
+            })
+            .disposed(by: bag)
+    }
+}
+
 // MARK: - Output
 extension ChallengeListBottomSheet {
     func bindTableView() {
@@ -183,4 +200,10 @@ extension ChallengeListBottomSheet: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
     }
+}
+
+// MARK: - Protocol
+
+protocol PushCreateChallengeVC: AnyObject {
+    func switchTabToChallengeAndPushCreateChallengeVC()
 }

--- a/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/ChallengeListBottomSheet.swift
@@ -103,7 +103,7 @@ extension ChallengeListBottomSheet {
         proceedingChallengeTV.delegate = self
         
         // Layout
-        contentView.snp.makeConstraints {
+        contentView.snp.updateConstraints {
             $0.height.equalTo(challengeCnt * cellHeight + 55 + Int(UIApplication.shared.window?.safeAreaInsets.bottom ?? 0))
         }
         

--- a/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/FriendProfileBottomSheet.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/FriendProfileBottomSheet.swift
@@ -127,7 +127,7 @@ class FriendProfileBottomSheet: DynamicBottomSheetViewController {
         }
     
     var nickname: String?
-    weak var delegate: DeselectAnnotation?
+    weak var delegate: FriendProfileProtocol?
     private let viewModel = FriendProfileVM()
     private let bag = DisposeBag()
     
@@ -403,10 +403,20 @@ extension FriendProfileBottomSheet: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        
+        guard let cell = tableView.cellForRow(at: indexPath) as? ProceedingChallengeTVC,
+              let uuid = cell.challengeUUID
+        else { return }
+        
+        dismiss(animated: true) {
+            self.delegate?.pushChallengeDetail(uuid)
+        }
     }
 }
 
 // MARK: - DeselectAnnotation Protocol
-protocol DeselectAnnotation: AnyObject {
+protocol FriendProfileProtocol: AnyObject {
     func deselectAnnotation()
+    
+    func pushChallengeDetail(_ uuid: String)
 }

--- a/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/FriendProfileBottomSheet.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/FriendProfileBottomSheet.swift
@@ -124,12 +124,14 @@ class FriendProfileBottomSheet: DynamicBottomSheetViewController {
                                              bottom: 0,
                                              right: 16)
             $0.backgroundColor = .white
+            $0.rowHeight = CGFloat(FriendProfileBottomSheet.cellHeight)
         }
     
     var nickname: String?
     weak var delegate: FriendProfileProtocol?
     private let viewModel = FriendProfileVM()
     private let bag = DisposeBag()
+    static let cellHeight = 69
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -193,13 +195,12 @@ extension FriendProfileBottomSheet {
         
         proceedingChallengeTV.register(ProceedingChallengeTVC.self,
                                        forCellReuseIdentifier: ProceedingChallengeTVC.className)
-        proceedingChallengeTV.delegate = self
         
         proceedingChallengeTV.snp.makeConstraints {
             $0.top.equalTo(listTitle.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide)
-            $0.height.equalTo(69 * challengeCnt)
+            $0.height.equalTo(FriendProfileBottomSheet.cellHeight * challengeCnt)
         }
     }
     
@@ -354,6 +355,20 @@ extension FriendProfileBottomSheet {
                 owner.proceedingChallengeTV.reloadData()
             })
             .disposed(by: bag)
+        
+        proceedingChallengeTV.rx.itemSelected
+            .asDriver()
+            .drive(onNext: { [weak self] indexPath in
+                guard let self = self,
+                      let cell = self.proceedingChallengeTV.cellForRow(at: indexPath) as? ProceedingChallengeTVC,
+                      let uuid = cell.challengeUUID
+                else { return }
+                self.proceedingChallengeTV.deselectRow(at: indexPath, animated: true)
+                self.dismiss(animated: true) {
+                    self.delegate?.pushChallengeDetail(uuid)
+                }
+            })
+            .disposed(by: bag)
     }
     
     
@@ -361,14 +376,14 @@ extension FriendProfileBottomSheet {
         viewModel.output.requestStatus
             .withUnretained(self)
             .subscribe(onNext: { owner, status in
-                self.popupToast(toastType: status ? .friendAdded : .networkError)
+                owner.popupToast(toastType: status ? .friendAdded : .networkError)
             })
             .disposed(by: bag)
         
         viewModel.output.deleteStatus
             .withUnretained(self)
             .subscribe(onNext: { owner, status in
-                self.popupToast(toastType: status ? .friendDeleted : .networkError)
+                owner.popupToast(toastType: status ? .friendDeleted : .networkError)
             })
             .disposed(by: bag)
     }
@@ -391,26 +406,6 @@ extension FriendProfileBottomSheet {
                 
                 return cell
             })
-    }
-}
-
-// MARK: - UITableViewDelegate
-
-extension FriendProfileBottomSheet: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        69.0
-    }
-    
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        
-        guard let cell = tableView.cellForRow(at: indexPath) as? ProceedingChallengeTVC,
-              let uuid = cell.challengeUUID
-        else { return }
-        
-        dismiss(animated: true) {
-            self.delegate?.pushChallengeDetail(uuid)
-        }
     }
 }
 

--- a/NEMODU/NEMODU/Screen/Map/ViewController/MainNC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/MainNC.swift
@@ -1,0 +1,15 @@
+//
+//  MainNC.swift
+//  NEMODU
+//
+//  Created by 황윤경 on 2023/05/13.
+//
+
+import UIKit
+
+class MainNC: BaseNavigationController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setViewControllers([MainVC()], animated: true)
+    }
+}

--- a/NEMODU/NEMODU/Screen/Map/ViewController/MainVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/MainVC.swift
@@ -408,16 +408,10 @@ extension MainVC {
 
 // MARK: - Protocol
 
-extension MainVC: PushCreateChallengeVC {
-    func switchTabToChallengeAndPushCreateChallengeVC() {
-        tabBarController?.selectedIndex = 0
-        
-        guard let challengeNC = tabBarController?.selectedViewController,
-              let challengeVC = challengeNC.children.first as? ChallengeRankingVC
-        else { return }
-
+extension MainVC: PushChallengeVC {
+    func pushCreateChallengeVC() {
         let selectChallengeCreateVC = SelectChallengeCreateVC()
         selectChallengeCreateVC.hidesBottomBarWhenPushed = true
-        challengeVC.navigationController?.pushViewController(selectChallengeCreateVC, animated: true)
+        navigationController?.pushViewController(selectChallengeCreateVC, animated: true)
     }
 }

--- a/NEMODU/NEMODU/Screen/Map/ViewController/MainVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/MainVC.swift
@@ -409,6 +409,15 @@ extension MainVC {
 // MARK: - Protocol
 
 extension MainVC: PushChallengeVC {
+    /// 진행중인 챌린지 상세 화면을 push하는 메서드
+    func pushChallengeDetail(_ uuid: String) {
+        let challengeDetailVC = ChallengeHistoryDetailVC()
+        challengeDetailVC.getChallengeHistoryDetailInfo(uuid: uuid)
+        challengeDetailVC.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(challengeDetailVC, animated: true)
+    }
+    
+    /// 챌린지 생성 화면을 push 하는 메서드
     func pushCreateChallengeVC() {
         let selectChallengeCreateVC = SelectChallengeCreateVC()
         selectChallengeCreateVC.hidesBottomBarWhenPushed = true

--- a/NEMODU/NEMODU/Screen/Map/ViewController/MainVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/MainVC.swift
@@ -256,6 +256,7 @@ extension MainVC {
             .drive(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 let challengeBottomSheet = ChallengeListBottomSheet()
+                challengeBottomSheet.delegate = self
                 self.present(challengeBottomSheet, animated: true)
             })
             .disposed(by: bag)
@@ -402,5 +403,21 @@ extension MainVC {
             .disposed(by: bag)
         
         // TODO: - myLocationVisible MVP2 부터 개발!!
+    }
+}
+
+// MARK: - Protocol
+
+extension MainVC: PushCreateChallengeVC {
+    func switchTabToChallengeAndPushCreateChallengeVC() {
+        tabBarController?.selectedIndex = 0
+        
+        guard let challengeNC = tabBarController?.selectedViewController,
+              let challengeVC = challengeNC.children.first as? ChallengeRankingVC
+        else { return }
+
+        let selectChallengeCreateVC = SelectChallengeCreateVC()
+        selectChallengeCreateVC.hidesBottomBarWhenPushed = true
+        challengeVC.navigationController?.pushViewController(selectChallengeCreateVC, animated: true)
     }
 }

--- a/NEMODU/NEMODU/Screen/Map/ViewController/MainVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/MainVC.swift
@@ -237,9 +237,16 @@ extension MainVC {
             .asDriver()
             .drive(onNext: { [weak self] _ in
                 guard let self = self else { return }
-                let countdownVC = CountdownVC()
-                countdownVC.modalPresentationStyle = .fullScreen
-                self.present(countdownVC, animated: true)
+                if self.mapVC.requestMotionAuthorization() {
+                    let countdownVC = CountdownVC()
+                    countdownVC.modalPresentationStyle = .fullScreen
+                    self.present(countdownVC, animated: true)
+                } else {
+                    self.popUpAlert(alertType: .requestMotionAuthority,
+                                    targetVC: self,
+                                    highlightBtnAction: #selector(self.openSystem),
+                                    normalBtnAction: #selector(self.dismissAlert))
+                }
             })
             .disposed(by: bag)
         

--- a/NEMODU/NEMODU/Screen/Map/ViewController/MapVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/MapVC.swift
@@ -211,8 +211,14 @@ extension MapVC {
         currentLocationBtn.rx.tap
             .asDriver()
             .drive(onNext: { [weak self] _ in
-                guard let self = self,
-                      let coordinate = self.locationManager.location?.coordinate else { return }
+                guard let self = self else { return }
+                guard let coordinate = self.locationManager.location?.coordinate else {
+                    self.popUpAlert(alertType: .requestLocationAuthority,
+                                    targetVC: self,
+                                    highlightBtnAction: #selector(self.openSystem),
+                                    normalBtnAction: #selector(self.dismissAlert))
+                    return
+                }
                 _ = self.goLocation(latitudeValue: coordinate.latitude,
                                     longitudeValue: coordinate.longitude,
                                     delta: Map.defaultZoomScale)
@@ -468,11 +474,11 @@ extension MapVC: CLLocationManagerDelegate {
             DispatchQueue.main.async {
                 self.locationManager.requestWhenInUseAuthorization()
             }
-        case .denied:
-            print("GPS 권한 요청 거부됨")
-            // TODO: - 알람창 띄우기
         default:
-            print("GPS: Default")
+            self.popUpAlert(alertType: .requestLocationAuthority,
+                            targetVC: self,
+                            highlightBtnAction: #selector(openSystem),
+                            normalBtnAction: #selector(dismissAlert))
         }
     }
     
@@ -526,6 +532,8 @@ extension MapVC: CLLocationManagerDelegate {
         self.previousCoordinate = location.coordinate
     }
 }
+
+// MARK: - MKMapViewDelegate
 
 extension MapVC: MKMapViewDelegate {
     /// 사용자 땅을 칠하는 함수 /
@@ -590,6 +598,8 @@ extension MapVC: MKMapViewDelegate {
         }
     }
 }
+
+// MARK: - DeselectAnnotation
 
 extension MapVC: DeselectAnnotation {
     /// 선택된 annotation을 모두 deselect 하는 메서드

--- a/NEMODU/NEMODU/Screen/Map/ViewController/MapVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/MapVC.swift
@@ -619,13 +619,21 @@ extension MapVC: MKMapViewDelegate {
     }
 }
 
-// MARK: - DeselectAnnotation
+// MARK: - FriendProfileProtocol
 
-extension MapVC: DeselectAnnotation {
+extension MapVC: FriendProfileProtocol {
     /// 선택된 annotation을 모두 deselect 하는 메서드
     func deselectAnnotation() {
         mapView.selectedAnnotations.forEach {
             mapView.deselectAnnotation($0, animated: true)
         }
+    }
+    
+    /// 진행중인 챌린지 상세 화면을 push하는 메서드
+    func pushChallengeDetail(_ uuid: String) {
+        let challengeDetailVC = ChallengeHistoryDetailVC()
+        challengeDetailVC.getChallengeHistoryDetailInfo(uuid: uuid)
+        challengeDetailVC.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(challengeDetailVC, animated: true)
     }
 }

--- a/NEMODU/NEMODU/Screen/Map/ViewController/MapVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/MapVC.swift
@@ -304,6 +304,26 @@ extension MapVC {
         }
     }
     
+    /// 디바이스의 건강 데이터를 요청하는 메서드
+    func requestMotionAuthorization() -> Bool {
+        let status = CMMotionActivityManager.authorizationStatus()
+        switch status {
+        case .notDetermined:
+            let today = Date()
+            var status = false
+            self.activityManager.queryActivityStarting(from: today, to: today, to: OperationQueue.main) { _, error in
+                status = error != nil
+            }
+            return status
+        case .restricted, .denied:
+            return false
+        case .authorized:
+            return true
+        @unknown default:
+            fatalError()
+        }
+    }
+    
     /// 사용자 activity를 추적하여 운동 상태와 걸음 수를 측정하는 함수
     func updateStep() {
         // TODO: - 자동차 or 자전거 사용 시 알람 정책 정한 후 수정

--- a/NEMODU/NEMODU/Screen/Map/ViewController/RecordResultVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/RecordResultVC.swift
@@ -100,6 +100,16 @@ class RecordResultVC: BaseViewController {
         bindDismiss()
     }
     
+    override func bindLoading() {
+        super.bindLoading()
+        viewModel.output.loading
+            .asDriver()
+            .drive(onNext: { [weak self] isLoading in
+                guard let self = self else { return }
+                self.loading(loading: isLoading)
+            })
+            .disposed(by: bag)
+    }
 }
 
 // MARK: - Configure

--- a/NEMODU/NEMODU/Screen/Map/ViewModel/RecordResultVM.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewModel/RecordResultVM.swift
@@ -66,6 +66,7 @@ extension RecordResultVM {
         let path = "record/end"
         let resource = urlResource<Bool>(path: path)
         
+        output.beginLoading()
         apiSession.postRequest(with: resource,
                                param: record.recordParam)
         .withUnretained(self)
@@ -76,6 +77,7 @@ extension RecordResultVM {
             case .success(let data):
                 owner.output.isValidPost.onNext(data)
             }
+            owner.output.endLoading()
         })
         .disposed(by: bag)
     }

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/EditProfileVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/EditProfileVC.swift
@@ -367,7 +367,7 @@ extension EditProfileVC {
                 let isProfileMessageChanged = self.viewModel.input.isProfileMessageChanged.value
                 
                 if isProfileImageChanged || isNicknameChanged || isProfileMessageChanged {
-                    self.popUpAlert(alertType: .profileEdited,
+                    self.popUpAlert(alertType: .discardChanges,
                                     targetVC: self,
                                     highlightBtnAction: #selector(self.dismissAlertAndPopVC),
                                     normalBtnAction: #selector(self.dismissAlert))

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/EditProfileVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/EditProfileVC.swift
@@ -126,11 +126,6 @@ extension EditProfileVC {
                                      titleColor: .main)
     }
     
-    /// 제스쳐로 뒤로가기 인터랙션 Enabled 상태를 지정하는 메서드
-    private func setInteractivePopGesture(_ isEnabled: Bool) {
-        navigationController?.interactivePopGestureRecognizer?.isEnabled = isEnabled
-    }
-    
     private func configureContentView() {
         view.addSubview(baseScrollView)
         baseScrollView.addSubview(contentView)

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/EditRecordMemoVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/EditRecordMemoVC.swift
@@ -23,6 +23,7 @@ class EditRecordMemoVC: BaseViewController {
     
     private let viewModel = EditRecordMemoVM()
     private let bag = DisposeBag()
+    weak var delegate: RecordMemoChanged?
     
     private var memo = ""
     private var recordId = -1
@@ -145,9 +146,16 @@ extension EditRecordMemoVC {
             .drive(onNext: { [weak self] validation in
                 guard let self = self else { return }
                 if validation {
-                    self.popVC()                    
+                    self.popVC()
+                    self.delegate?.popupToastView()
                 }
             })
             .disposed(by: bag)
     }
+}
+
+// MARK: - RecordMemoChanged Protocol
+
+protocol RecordMemoChanged: AnyObject {
+    func popupToastView()
 }

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/EditRecordMemoVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/EditRecordMemoVC.swift
@@ -29,6 +29,12 @@ class EditRecordMemoVC: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setInteractivePopGesture(false)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        setInteractivePopGesture(true)
     }
     
     override func configureView() {
@@ -44,6 +50,7 @@ class EditRecordMemoVC: BaseViewController {
     
     override func bindInput() {
         super.bindInput()
+        bindBackBtn()
         bindSaveBtn()
     }
     
@@ -102,6 +109,27 @@ extension EditRecordMemoVC {
                 } else {
                     self.viewModel.postEditedData(with: EditMemoRequestModel(message: self.memoTextView.tv.text,
                                                                              recordId: self.recordId))
+                }
+            })
+            .disposed(by: bag)
+    }
+    
+    private func bindBackBtn() {
+        // 기존 뒤로가기 pop 액션 remove
+        naviBar.backBtn.removeTarget(self,
+                                     action: #selector(self.popVC),
+                                     for: .touchUpInside)
+        // 값 상태에 따라 binding
+        naviBar.backBtn.rx.tap
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                if self.memoTextView.tv.text != self.memo {
+                    self.popUpAlert(alertType: .discardChanges,
+                                    targetVC: self,
+                                    highlightBtnAction: #selector(self.dismissAlertAndPopVC),
+                                    normalBtnAction: #selector(self.dismissAlert))
+                } else {
+                    self.popVC()
                 }
             })
             .disposed(by: bag)

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/FriendListVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/FriendListVC.swift
@@ -38,6 +38,7 @@ class FriendListVC: BaseViewController {
             $0.separatorStyle = .none
             $0.isScrollEnabled = false
             $0.backgroundColor = .clear
+            $0.rowHeight = 64
         }
     
     private let friendListView = UIView()
@@ -77,6 +78,8 @@ class FriendListVC: BaseViewController {
     private let friendListTV = UITableView()
         .then {
             $0.separatorStyle = .none
+            $0.backgroundColor = .clear
+            $0.rowHeight = 64
         }
     
     private var isFriendListEditing = false
@@ -125,11 +128,9 @@ extension FriendListVC {
         
         requestTV.register(FriendRequestTVC.self, forCellReuseIdentifier: FriendRequestTVC.className)
         requestTV.dataSource = self
-        requestTV.delegate = self
         
         friendListTV.register(FriendListTVC.self, forCellReuseIdentifier: FriendListTVC.className)
         friendListTV.dataSource = self
-        friendListTV.delegate = self
     }
 }
 
@@ -241,13 +242,5 @@ extension FriendListVC: UITableViewDataSource {
             friendListCell.configureCell(isEdit: isFriendListEditing)
             return friendListCell
         }
-    }
-}
-
-// MARK: - UITableViewDelegate
-
-extension FriendListVC: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        64
     }
 }

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDataVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDataVC.swift
@@ -127,6 +127,7 @@ class MyRecordDataVC: BaseViewController {
         super.bindOutput()
         bindTableView()
         bindCalendarReload()
+        bindNoneDataMessage()
     }
     
 }
@@ -368,6 +369,16 @@ extension MyRecordDataVC {
 // MARK: - Output
 
 extension MyRecordDataVC {
+    private func bindNoneDataMessage() {
+        viewModel.output.isRecordEmpty
+            .asDriver(onErrorJustReturn: true)
+            .drive(onNext: { [weak self] isEmpty in
+                guard let self = self else { return }
+                self.noneMessage.isHidden = !isEmpty
+            })
+            .disposed(by: bag)
+    }
+    
     private func bindTableView() {
         viewModel.output.dataSource
             .bind(to: recordTableView.rx.items(dataSource: tableViewDataSource()))

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDataVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDataVC.swift
@@ -80,6 +80,7 @@ class MyRecordDataVC: BaseViewController {
         .then {
             $0.backgroundColor = .clear
             $0.separatorStyle = .none
+            $0.rowHeight = 76 + 12
         }
     
     private let naviBar = NavigationBar()
@@ -160,7 +161,6 @@ extension MyRecordDataVC {
         calendarCV.register(DayCVC.self, forCellWithReuseIdentifier: DayCVC.className)
         
         recordTableView.register(MyRecordListTVC.self, forCellReuseIdentifier: MyRecordListTVC.className)
-        recordTableView.delegate = self
     }
     
     private func configureCalendarCV() {
@@ -427,17 +427,9 @@ extension MyRecordDataVC {
     }
 }
 
-// MARK: - UITableViewDelegate
+// MARK: - UICollectionViewDelegate
 
-extension MyRecordDataVC: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        76.0 + 12.0
-    }
-    
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-    }
-    
+extension MyRecordDataVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         // 미래 선택 불가능
         guard let cell = collectionView.cellForItem(at: indexPath) as? DayCVC,
@@ -446,7 +438,7 @@ extension MyRecordDataVC: UITableViewDelegate {
     }
 }
 
-// MARK: - UICollectionViewDelegate
+// MARK: - UICollectionViewDelegateFlowLayout
 
 extension MyRecordDataVC: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
@@ -123,9 +123,10 @@ class MyRecordDetailVC: BaseViewController {
             $0.separatorStyle = .singleLine
             $0.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
             $0.backgroundColor = .white
+            $0.rowHeight = CGFloat(MyRecordDetailVC.challengeListCellHeight)
         }
 
-    private let challengeListCellHeight = 69
+    static let challengeListCellHeight = 69
     private let subTitleLabelHeight = 52
     private let separatorHeight = 2
     
@@ -207,7 +208,6 @@ extension MyRecordDetailVC {
     private func configureChallengeListTV() {
         proceedingChallengeTV.register(ProceedingChallengeTVC.self,
                                        forCellReuseIdentifier: ProceedingChallengeTVC.className)
-        proceedingChallengeTV.delegate = self
     }
     
     private func configureRecordValue(recordData: DetailRecordDataResponseModel) {
@@ -335,7 +335,7 @@ extension MyRecordDetailVC {
         let titleHeight = cnt == 0 ? 0 : subTitleLabelHeight + separatorHeight
         
         challengeListView.snp.makeConstraints {
-            $0.height.equalTo(titleHeight + cnt * challengeListCellHeight)
+            $0.height.equalTo(titleHeight + cnt * MyRecordDetailVC.challengeListCellHeight)
         }
     }
 }
@@ -395,6 +395,15 @@ extension MyRecordDetailVC {
                 owner.setChallengeListViewHeight(cnt: item.count)
             })
             .disposed(by: bag)
+        
+        proceedingChallengeTV.rx.itemSelected
+            .asDriver()
+            .drive(onNext: { [weak self] indexPath in
+                guard let self = self else { return }
+                self.proceedingChallengeTV.deselectRow(at: indexPath, animated: true)
+                // TODO: - 챌린지 연결
+            })
+            .disposed(by: bag)
     }
 }
 
@@ -415,18 +424,6 @@ extension MyRecordDetailVC {
                 
                 return cell
             })
-    }
-}
-
-// MARK: - UITableViewDelegate
-
-extension MyRecordDetailVC: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        CGFloat(challengeListCellHeight)
-    }
-    
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
     }
 }
 

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
@@ -350,6 +350,7 @@ extension MyRecordDetailVC {
                 guard let self = self,
                       let recordId = self.recordID else { return }
                 let editRecordMomoVC = EditRecordMemoVC()
+                editRecordMomoVC.delegate = self
                 editRecordMomoVC.getRecordData(recordId: recordId,
                                                memo: self.memoTextView.tv.text)
                 self.navigationController?.pushViewController(editRecordMomoVC, animated: true)
@@ -426,5 +427,13 @@ extension MyRecordDetailVC: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+// MARK: - RecordMemoChanged Protocol
+
+extension MyRecordDetailVC: RecordMemoChanged {
+    func popupToastView() {
+        popupToast(toastType: .saveCompleted)
     }
 }

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
@@ -399,9 +399,16 @@ extension MyRecordDetailVC {
         proceedingChallengeTV.rx.itemSelected
             .asDriver()
             .drive(onNext: { [weak self] indexPath in
-                guard let self = self else { return }
+                guard let self = self,
+                      let cell = self.proceedingChallengeTV.cellForRow(at: indexPath) as? ProceedingChallengeTVC,
+                      let uuid = cell.challengeUUID
+                else { return }
                 self.proceedingChallengeTV.deselectRow(at: indexPath, animated: true)
-                // TODO: - 챌린지 연결
+                
+                let challengeDetailVC = ChallengeHistoryDetailVC()
+                challengeDetailVC.getChallengeHistoryDetailInfo(uuid: uuid)
+                challengeDetailVC.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(challengeDetailVC, animated: true)
             })
             .disposed(by: bag)
     }

--- a/NEMODU/NEMODU/Screen/Mypage/ViewModel/MyRecordDataVM.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewModel/MyRecordDataVM.swift
@@ -49,6 +49,7 @@ final class MyRecordDataVM: BaseViewModel {
                 }
         }
         var calendarReload = PublishSubject<Bool>()
+        var isRecordEmpty = PublishRelay<Bool>()
     }
     
     // MARK: - Init
@@ -199,6 +200,7 @@ extension MyRecordDataVM {
                 case .failure(let error):
                     owner.apiError.onNext(error)
                 case .success(let data):
+                    owner.output.isRecordEmpty.accept(data.activityRecords.count == 0)
                     owner.output.myRecordList.accept(data.activityRecords)
                 }
             })

--- a/NEMODU/NEMODU/Screen/Onboarding/OnboardingVC.swift
+++ b/NEMODU/NEMODU/Screen/Onboarding/OnboardingVC.swift
@@ -99,7 +99,7 @@ class OnboardingVC: BaseViewController {
     
     override func bindInput() {
         super.bindInput()
-        bindScrollView()
+        bindScrollWithPage()
     }
     
     override func bindOutput() {
@@ -132,7 +132,8 @@ extension OnboardingVC {
         progressStackView.arrangedSubviews[0].backgroundColor = .gray900
     }
     
-    private func setPage(_ page: Int) {
+    /// 페이지에 따라 progressStackView의 상태를 변경하는 메서드
+    private func setPageControlSelectedPage(_ page: Int) {
         for i in 0..<pageCnt {
             progressStackView.arrangedSubviews[i].backgroundColor
             = page == i
@@ -140,7 +141,8 @@ extension OnboardingVC {
         }
     }
     
-    private func setBtnActive(_ active: Bool) {
+    /// 시작하기 버튼의 활성 상태를 변경하는 메서드
+    private func setStartBtnActive(_ active: Bool) {
         startBtn.isUserInteractionEnabled = active
         startBtn.backgroundColor = active ? .main : .gray100
         startBtn.tintColor = active ? .white : .gray400
@@ -231,15 +233,15 @@ extension OnboardingVC {
 // MARK: - Input
 
 extension OnboardingVC {
-    private func bindScrollView() {
-        baseScrollView.rx.panGesture()
-            .when(.ended)
+    /// scrollView의 스크롤에 따라 페이지를 연결하는 메서드
+    private func bindScrollWithPage() {
+        baseScrollView.rx.didEndDecelerating
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 let page = round(self.baseScrollView.contentOffset.x / self.screenWidth)
                 if page.isNaN || page.isInfinite { return }
-                self.setBtnActive(page == 2)
-                self.setPage(Int(page))
+                self.setStartBtnActive(page == 2)
+                self.setPageControlSelectedPage(Int(page))
             })
             .disposed(by: bag)
     }

--- a/NEMODU/NEMODU/Screen/Onboarding/OnboardingVC.swift
+++ b/NEMODU/NEMODU/Screen/Onboarding/OnboardingVC.swift
@@ -204,9 +204,20 @@ extension OnboardingVC {
             $0.trailing.equalTo(firstView.title.snp.trailing)
         }
         
+        /// 이미지 비율 기준값
+        /// 첫번째
+        ///  - 가로 길이: 화면의 0.65배
+        /// 두번째
+        ///  - leading, trailing 값 비율로 가로 길이 결정
+        /// 세번째
+        ///  - 가로 길이: 화면의 0.65배
+        
+        let firstImageRatio = (firstView.baseImageView.image?.size.height ?? 1) / (firstView.baseImageView.image?.size.width ?? 1)
         firstView.baseImageView.snp.makeConstraints {
             $0.trailing.equalToSuperview().offset(10)
             $0.bottom.equalTo(startBtn.snp.top).offset(-38)
+            $0.width.equalToSuperview().multipliedBy(0.65)
+            $0.height.equalTo(firstView.baseImageView.snp.width).multipliedBy(firstImageRatio)
         }
         
         secondView.emphasis.snp.makeConstraints {
@@ -214,18 +225,24 @@ extension OnboardingVC {
             $0.width.equalTo(71)
         }
         
+        let secondImageRatio = (secondView.baseImageView.image?.size.height ?? 1) / (secondView.baseImageView.image?.size.width ?? 1)
         secondView.baseImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(screenWidth/15)
             $0.trailing.equalToSuperview()
             $0.bottom.equalTo(startBtn.snp.top).offset(-63)
+            $0.height.equalTo(secondView.baseImageView.snp.width).multipliedBy(secondImageRatio)
         }
         
         thirdView.emphasis.snp.makeConstraints {
             $0.trailing.equalTo(thirdView.title.snp.trailing).offset(4)
         }
         
+        let thirdImageRatio = (thirdView.baseImageView.image?.size.height ?? 1) / (thirdView.baseImageView.image?.size.width ?? 1)
         thirdView.baseImageView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.bottom.equalTo(startBtn.snp.top).offset(-78)
+            $0.width.equalToSuperview().multipliedBy(0.65)
+            $0.height.equalTo(thirdView.baseImageView.snp.width).multipliedBy(thirdImageRatio)
         }
     }
 }

--- a/NEMODU/NEMODU/Screen/Share/View/AlertVC.swift
+++ b/NEMODU/NEMODU/Screen/Share/View/AlertVC.swift
@@ -125,6 +125,12 @@ extension AlertVC {
         // 버튼 한 개
         case .defaultNetworkError, .requestLocationAuthority, .realTimeChallenge, .createWeekChallenge, .sendMailError:
             btnStackView.addArrangedSubview(highlightBtn)
+        // 버튼 세로 두 개
+        case .requestMotionAuthority:
+            btnStackView.axis = .vertical
+            [highlightBtn, normalBtn].forEach {
+                btnStackView.addArrangedSubview($0)
+            }
         // 버튼 가로 두 개
         case .recordNetworkError, .minimumBlocks, .speedWarning, .profileEdited:
             btnStackView.axis = .horizontal

--- a/NEMODU/NEMODU/Screen/Share/View/AlertVC.swift
+++ b/NEMODU/NEMODU/Screen/Share/View/AlertVC.swift
@@ -105,7 +105,8 @@ extension AlertVC {
         view.addSubview(alertBaseView)
         alertBaseView.addSubviews([baseStackView,
                                    btnStackView])
-        [alertImage, alertTitle, alertMessage].forEach {
+        var alertBase = [alertImage, alertTitle] + ((alertMessage.text != nil) ? [alertMessage] : [])
+        alertBase.forEach {
             baseStackView.addArrangedSubview($0)
         }
     }
@@ -132,7 +133,7 @@ extension AlertVC {
                 btnStackView.addArrangedSubview($0)
             }
         // 버튼 가로 두 개
-        case .recordNetworkError, .minimumBlocks, .speedWarning, .profileEdited:
+        case .recordNetworkError, .minimumBlocks, .speedWarning, .discardChanges:
             btnStackView.axis = .horizontal
             [normalBtn, highlightBtn].forEach {
                 btnStackView.addArrangedSubview($0)

--- a/NEMODU/NEMODU/Screen/Share/View/AlertVC.swift
+++ b/NEMODU/NEMODU/Screen/Share/View/AlertVC.swift
@@ -123,14 +123,8 @@ extension AlertVC {
         normalBtn.setTitle(alertType.normalBtnTitle, for: .normal)
         switch alertType {
         // 버튼 한 개
-        case .defaultNetworkError, .realTimeChallenge, .createWeekChallenge, .sendMailError:
+        case .defaultNetworkError, .requestLocationAuthority, .realTimeChallenge, .createWeekChallenge, .sendMailError:
             btnStackView.addArrangedSubview(highlightBtn)
-        // 버튼 세로 두 개
-        case .requestAuthority:
-            btnStackView.axis = .vertical
-            [highlightBtn, normalBtn].forEach {
-                btnStackView.addArrangedSubview($0)
-            }
         // 버튼 가로 두 개
         case .recordNetworkError, .minimumBlocks, .speedWarning, .profileEdited:
             btnStackView.axis = .horizontal

--- a/NEMODU/NEMODU/Screen/Share/View/ToastView.swift
+++ b/NEMODU/NEMODU/Screen/Share/View/ToastView.swift
@@ -59,7 +59,7 @@ extension ToastView {
                 baseStackView.addArrangedSubview($0)
             }
             setImageSize()
-        case .friendAdded, .friendDeleted, .profileChanged:
+        case .friendAdded, .friendDeleted, .profileChanged, .saveCompleted:
             baseStackView.addArrangedSubview(toastMessage)
         }
     }

--- a/NEMODU/NEMODU/Screen/TabBar/NEMODUTBC.swift
+++ b/NEMODU/NEMODU/Screen/TabBar/NEMODUTBC.swift
@@ -38,7 +38,7 @@ extension NEMODUTBC {
         
         // 탭 구성
         let challengeRankingTab = makeTabVC(vc: ChallengeRankingNC(), tabBarTitle: "챌린지/랭킹", tabBarImage: "TabBarIcon/challengeRanking" , tabBarSelectedImage: "TabBarIcon/challengeRanking_fill")
-        let mapTab = makeTabVC(vc: MainVC(), tabBarTitle: "지도", tabBarImage: "TabBarIcon/map", tabBarSelectedImage: "TabBarIcon/map_fill")
+        let mapTab = makeTabVC(vc: MainNC(), tabBarTitle: "지도", tabBarImage: "TabBarIcon/map", tabBarSelectedImage: "TabBarIcon/map_fill")
         let mypageTab = makeTabVC(vc: MypageNC(), tabBarTitle: "MY", tabBarImage: "TabBarIcon/mypage", tabBarSelectedImage: "TabBarIcon/mypage_fill")
         
         let tabs =  [challengeRankingTab, mapTab, mypageTab]

--- a/NEMODU/NEMODU/Support/Info.plist
+++ b/NEMODU/NEMODU/Support/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/NEMODU/NEMODU/Support/Info.plist
+++ b/NEMODU/NEMODU/Support/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## PR 요약
그동안 존재하던 자잘한 이슈들을 정리하였습니다.
에러 처리, 레이아웃 대공사 등은 따로 브랜치를 파서 진행할 예정입니다.

## 변경 사항
- 온보딩 pageControl 오류 수정
   - endDragging으로 구현해서 생겼던 문제. endDecelerating으로 변경
   - 이제 힘차게 넘기지 않아도 됩니다^~^
-  [확인 요망] 챌린지 키보드 완료 키 기능 추가
   - 주간 챌린지를 생성하는 화면에 챌린지 이름을 입력하는 텍스트 필드가 일반 텍스트 필드로 구현되어 있어 네모두 텍스트필드로 변경하였습니다.
   - 높이값 수정하였습니다.
   - return 키를 누르면 키보드가 내려갈 수 있도록 delegate를 연결하였습니다.
   - 네모두 텍스트필드는 return키의 기본 값을 done으로 지정했고 텍스트뷰는 엔터 기능으로 그대로 두었습니다.
   - 일단 다 확인했는데 또 빠진 부분 있으면 말해주세용
- 위치 동의 화면 이미지 비율 조정
   - 항상 동일한 비율로 라벨과 일정 거리를 유지하며 존재하도록 추가
   - 아이패드에서도 깨지지 않아용
- 마이페이지 캘린더 
   - 운동 기록 목록 tableView에 데이터가 없는 경우와 있는 경우 처리
- 회원가입에 로딩뷰 넣기
- (임시) 다크모드 막기
   - 디자인팀 다크모드 생성 전까지는 다크모드 막아두기

## + 추가됨
- 홈화면 진행중인 챌린지 목록 높이 동적으로 변경
  - 원래는 기본 높이로 고정되어있어 하단 여백이 너무 눈에 거슬려서 높이를 동적으로 바꿨습니다.
  - 이 부분은 차후 intinsicContentSize에 맞는 높이를 지정하는 TableView를 따로 구현해서 다시 바꿀고임
  이거 상속해서 테이블 뷰 두개 넣는 방법으로 가면 챌린지 화면 관리 쉬워질거예용!
   #180 
  - 챌린지 생성 및 상세보기 연결
- 회원가입 디바이스 타입 추가
- FriendStatusType Enum값 변경(_ 추가)
- 친구 프로필 챌린지 연결
- 운동기록 상세
  - 챌린지 연결
  - 메모 수정 알림창 & 제스쳐 뒤로가기 막기 & 완료시 토스트 메세지 연결
- 헬스 데이터 접근 동의 -> 운동 기록 버튼 눌렀을때 확인 받는걸로 변경
- 온보딩 이미지 비율 오토레이아웃 적용
- (임시) 세로모드만 허용, 패드는 뒤집어서도 가능
- tableView Delegate 호출 비용 줄임
  - 애플 공식 문서에서 나와있는 것 처럼 불필요한 delegate 호출을 줄이기 위해 높이가 동일할 경우 heightForRowAt -> rowHeight로 변경
  - select 이벤트도 rx로 변경 (이건 그냥 가독성 용. 이벤트 처리가 분산되어있어서 확인 및 관리가 어려워서 바꿈)
- 운동 기록 전송 -> 로딩 넣기

##  ScreenShot


#### Linked Issue
close #166 

