### PR TITLE
Feat/#180 ContentSize에 따른 높이를 갖는 TableView 구현

### DIFF
--- a/NEMODU/NEMODU.xcodeproj/project.pbxproj
+++ b/NEMODU/NEMODU.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		23D8B7E528B4D5AA00F48165 /* CalendarSelectStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D8B7E428B4D5AA00F48165 /* CalendarSelectStackView.swift */; };
 		23D8B7E728B4E44700F48165 /* MyRecordDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D8B7E628B4E44700F48165 /* MyRecordDetailVC.swift */; };
 		23ECC09F28D859E000F65692 /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23ECC09E28D859E000F65692 /* AuthAPI.swift */; };
+		23EE33572A0FF4CD00EC50E7 /* ContentSizedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EE33562A0FF4CD00EC50E7 /* ContentSizedTableView.swift */; };
 		23EFB81C29113A00009A2D01 /* RefreshBtnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EFB81B29113A00009A2D01 /* RefreshBtnView.swift */; };
 		23EFB829291A0D9E009A2D01 /* EditProfileResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EFB828291A0D9E009A2D01 /* EditProfileResponseModel.swift */; };
 		23F5716928A6802C005F2E21 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F5716828A6802C005F2E21 /* UIStackView+.swift */; };
@@ -416,6 +417,7 @@
 		23D8B7E428B4D5AA00F48165 /* CalendarSelectStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSelectStackView.swift; sourceTree = "<group>"; };
 		23D8B7E628B4E44700F48165 /* MyRecordDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRecordDetailVC.swift; sourceTree = "<group>"; };
 		23ECC09E28D859E000F65692 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
+		23EE33562A0FF4CD00EC50E7 /* ContentSizedTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSizedTableView.swift; sourceTree = "<group>"; };
 		23EFB81B29113A00009A2D01 /* RefreshBtnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshBtnView.swift; sourceTree = "<group>"; };
 		23EFB828291A0D9E009A2D01 /* EditProfileResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileResponseModel.swift; sourceTree = "<group>"; };
 		23F5716828A6802C005F2E21 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
@@ -708,6 +710,7 @@
 				232F0B6228B6803C005C9A07 /* AlertVC.swift */,
 				2312519528B6944B00DF1C69 /* ToastView.swift */,
 				237573EA28FA5A00006026ED /* ProfileImageVC.swift */,
+				23EE33562A0FF4CD00EC50E7 /* ContentSizedTableView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1634,6 +1637,7 @@
 				23ECC09F28D859E000F65692 /* AuthAPI.swift in Sources */,
 				23B7205D28A0CBAC00D3A410 /* ChallengeListBottomSheet.swift in Sources */,
 				2348B4122892D901001095BC /* LoadingView.swift in Sources */,
+				23EE33572A0FF4CD00EC50E7 /* ContentSizedTableView.swift in Sources */,
 				3C08137E28A91C00009F854B /* ChallengeTitleTVHV.swift in Sources */,
 				3C08137E28A91C00009F854B /* ChallengeTitleTVHV.swift in Sources */,
 				2348B3DD2892CF92001095BC /* MapVC.swift in Sources */,

--- a/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/MapFilterBottomSheet.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/BottomSheet/MapFilterBottomSheet.swift
@@ -123,10 +123,6 @@ extension MapFilterBottomSheet {
         btnStackView.addArrangedSubview(showMyBlocksBtn)
         btnStackView.addArrangedSubview(showFriendsBtn)
         
-        contentView.snp.makeConstraints {
-            $0.height.equalTo(340)
-        }
-        
         viewBar.snp.makeConstraints {
             $0.width.equalTo(32)
             $0.height.equalTo(4)
@@ -171,6 +167,7 @@ extension MapFilterBottomSheet {
         locationPermissionToggleBtn.snp.makeConstraints {
             $0.centerY.equalTo(locationPermissionMessage)
             $0.trailing.equalToSuperview().offset(-16)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-25)
         }
     }
 }

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
@@ -117,7 +117,7 @@ class MyRecordDetailVC: BaseViewController {
             $0.backgroundColor = .gray50
         }
     
-    private let proceedingChallengeTV = UITableView(frame: .zero)
+    private let proceedingChallengeTV = ContentSizedTableView(frame: .zero)
         .then {
             $0.isScrollEnabled = false
             $0.separatorStyle = .singleLine
@@ -329,15 +329,6 @@ extension MyRecordDetailVC {
             $0.bottom.equalToSuperview()
         }
     }
-    
-    private func setChallengeListViewHeight(cnt: Int) {
-        challengeListView.isHidden = cnt == 0
-        let titleHeight = cnt == 0 ? 0 : subTitleLabelHeight + separatorHeight
-        
-        challengeListView.snp.makeConstraints {
-            $0.height.equalTo(titleHeight + cnt * MyRecordDetailVC.challengeListCellHeight)
-        }
-    }
 }
 
 // MARK: - Input
@@ -390,9 +381,7 @@ extension MyRecordDetailVC {
         viewModel.output.challengeList
             .withUnretained(self)
             .subscribe(onNext: { owner, item in
-                if item.count == 0 { return }
                 owner.proceedingChallengeTV.reloadData()
-                owner.setChallengeListViewHeight(cnt: item.count)
             })
             .disposed(by: bag)
         

--- a/NEMODU/NEMODU/Screen/Share/View/ContentSizedTableView.swift
+++ b/NEMODU/NEMODU/Screen/Share/View/ContentSizedTableView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentSizedTableView.swift
+//  NEMODU
+//
+//  Created by 황윤경 on 2023/05/14.
+//
+
+import UIKit
+
+final class ContentSizedTableView: UITableView {
+    override var contentSize: CGSize {
+        didSet {
+            invalidateIntrinsicContentSize()
+        }
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        layoutIfNeeded()
+        return CGSize(width: UIView.noIntrinsicMetric, height: contentSize.height)
+    }
+}


### PR DESCRIPTION
## PR 요약
### 내부 intrinsicContentSize에 맞춰 높이를 자동으로 할당하는 tableView 구현

- 네모두에는 scrollView 내부에 tableView가 있고 스크롤은 scrollView만 담당하는 뷰가 많이 있습니다.
매번 tableView의 높이를 계산해서 레이아웃을 잡아주는 비용을 없애고 자동으로 내부 contentSize에 따라 높이를 할당해주는 ContentSizedTableView를 구현하였습니다.
- DynamicBottomSheetViewController를 통해 구현하는 메인화면의 친구 프로필, 챌린지 목록의 경우 기본적으로 데이터가 없을때의 view의 contentSize가 이미 잡혀있는 상태고 이를 업데이트 해줘야하기때문에 해당 테이블뷰를 적용하지 않고 기본 방식을 유지하였습니다.
- 챌린지나 기타 여러 화면에서 유용하게 사용될 수 있을 것 같아요! 리팩토링하실때 적용해보시면 그동안 고민하셨던 부분이 어느정도 해결되지 않을까 기대합니당


## 변경 사항
- 마이페이지 기록 상세 보기의 챌린지 목록 tableView를 ContentSizedTableView로 변경

##  ScreenShot


#### Linked Issue
close #180 

