### PR TITLE
Chore/#184 내 운동 기록 -> 챌린지 연결 수정

### DIFF
--- a/NEMODU/NEMODU/Screen/Map/Cell/TVC/ProceedingChallengeTVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/Cell/TVC/ProceedingChallengeTVC.swift
@@ -52,7 +52,7 @@ class ProceedingChallengeTVC: UITableViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        challengeIcon.image = nil
+        challengeIcon.tintColor = .clear
         challengeTitle.text = nil
         challengeSubtitle.text = nil
         challengeUUID = nil

--- a/NEMODU/NEMODU/Screen/Map/Cell/TVC/ProceedingChallengeTVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/Cell/TVC/ProceedingChallengeTVC.swift
@@ -36,6 +36,7 @@ class ProceedingChallengeTVC: UITableViewCell {
         }
     
     var challengeUUID: String?
+    var endDate: Date?
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -94,6 +95,7 @@ extension ProceedingChallengeTVC {
         challengeIcon.tintColor = ChallengeColorType(rawValue: element.color)?.primaryColor ?? .gray500
         challengeTitle.text = element.name
         challengeUUID = element.uuid
+        endDate = element.ended.toDate(.hyphen)
         
         if let rank = element.rank {
             challengeSubtitle.text = isMyList

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
@@ -392,9 +392,15 @@ extension MyRecordDetailVC {
                       let cell = self.proceedingChallengeTV.cellForRow(at: indexPath) as? ProceedingChallengeTVC,
                       let uuid = cell.challengeUUID
                 else { return }
+                // deselect
                 self.proceedingChallengeTV.deselectRow(at: indexPath, animated: true)
                 
+                // 챌린지 종료 확인
+                let isChallengeOver = (cell.endDate != nil) ? (cell.endDate?.compare(.now) == ComparisonResult.orderedAscending) : true
+                
+                // 챌린지 상세 화면 연결
                 let challengeDetailVC = ChallengeHistoryDetailVC()
+                if isChallengeOver { challengeDetailVC.configureChallengeDoneLayout() }
                 challengeDetailVC.getChallengeHistoryDetailInfo(uuid: uuid)
                 challengeDetailVC.hidesBottomBarWhenPushed = true
                 self.navigationController?.pushViewController(challengeDetailVC, animated: true)


### PR DESCRIPTION
## PR 요약
- 내 운동 기록 화면에서 진행한 챌린지 상세보기 화면 연결을
진행중인 챌린지 / 진행 완료된 챌린지를 구분해서 띄울 수 있도록 수정하였습니다.
- prepareForReuse에 tintColor을 nil로 넣어야하는데 image를 nil로 넣어서 이미지가 사라지던..! 문제를 고쳤습니다.

## 변경 사항
- 챌린지 뷰컨 생성 및 연결 부분 말씀해주신대로 일단 넣었는데 더미데이터가 없어서 충분한 테스트는 거치지 못했습니다. 확인해주시구 빠진 부분 있으면 말씀해주세여!!

##  ScreenShot


#### Linked Issue
close #184 

