### PR TITLE
Chore/#183 my record response model

### DIFF
--- a/NEMODU/NEMODU/Global/Enum/DateType.swift
+++ b/NEMODU/NEMODU/Global/Enum/DateType.swift
@@ -8,23 +8,35 @@
 import Foundation
 
 enum DateType {
+    /// yyyy-MM-dd'T'HH:mm:ss
     case withTime
+    /// yyyy-MM-dd
     case hyphen
+    /// yyyy-MM-dd'T'
     case withT
+    /// yyyy-MM-dd HH:mm:ss
     case withBlank
+    /// 24시간제 시간
+    case hourClock24
+    /// 12시간제 시간
+    case hourClock12
 }
 
 extension DateType {
     var dateFormatter: String {
         switch self {
-        case .hyphen:
-            return "yyyy-MM-dd"
         case .withTime:
             return "yyyy-MM-dd'T'HH:mm:ss"
+        case .hyphen:
+            return "yyyy-MM-dd"
         case .withT:
             return "yyyy-MM-dd'T'"
         case .withBlank:
             return "yyyy-MM-dd HH:mm:ss"
+        case .hourClock24:
+            return "HH:mm"
+        case .hourClock12:
+            return "hh:mm"
         }
     }
 }

--- a/NEMODU/NEMODU/Global/Extension/Date+.swift
+++ b/NEMODU/NEMODU/Global/Extension/Date+.swift
@@ -43,9 +43,18 @@ extension Date {
     func getDayOfWeek() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "EEEEEE"
-        formatter.locale = Locale(identifier:"ko_KR")
+        formatter.locale = Locale(identifier: "ko_KR")
         let convertStr = formatter.string(from: self)
         return convertStr
+    }
+    
+    /// 특정 날짜의 시간을 반환
+    func toTime(_ dateFormatter: DateType) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = dateFormatter.dateFormatter
+        formatter.locale = Locale(identifier: "ko_KR")
+        let time = formatter.string(from: self)
+        return time
     }
 }
 

--- a/NEMODU/NEMODU/Global/Extension/Int+.swift
+++ b/NEMODU/NEMODU/Global/Extension/Int+.swift
@@ -8,16 +8,19 @@
 import Foundation
 
 extension Int {
+    /// 콤마(,)를 추가한 String 반환
     var insertComma: String {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         return numberFormatter.string(from: NSNumber(value: self))!
     }
     
+    /// 두 자리로 formatting한 String 반환
     var showTwoDigitNumber: String {
         String(format: "%02d", self)
     }
     
+    /// m를 km로 반환
     var toKilometer: String {
         let formatter = LengthFormatter()
         formatter.numberFormatter.maximumFractionDigits = 2
@@ -28,5 +31,14 @@ extension Int {
             let value = Double(self)
             return formatter.string(fromValue: value, unit: LengthFormatter.Unit.meter)
         }
+    }
+    
+    /// 네모두만의 운동 시간 표현 (초 -> 분:초)
+    /// 60분 넘어가도 분으로만 표현 & 분은 한자리 표현 & 초는 두 자리 표현
+    var toExerciseTime: String {
+        let m = self / 60
+        let s = self % 60
+        
+        return "\(m):\(s.showTwoDigitNumber)"
     }
 }

--- a/NEMODU/NEMODU/Screen/Map/ViewController/WalkingVC.swift
+++ b/NEMODU/NEMODU/Screen/Map/ViewController/WalkingVC.swift
@@ -70,7 +70,7 @@ class WalkingVC: BaseViewController {
     
     private let timeView = RecordView()
         .then {
-            $0.recordValue.text = "0:00"
+            $0.recordValue.text = "00:00"
             $0.recordTitle.text = "시간"
             $0.recordSubtitle.text = " "
         }
@@ -297,8 +297,7 @@ extension WalkingVC {
                 if self.mapVC.isWalking ?? false {
                     self.secondTimeValue += second
                     self.timeView.recordValue.text
-                    = "\(self.secondTimeValue / 60):"
-                    + String(format: "%02d", self.secondTimeValue % 60)
+                    = self.secondTimeValue.toExerciseTime
                 }
             })
             .disposed(by: bag)

--- a/NEMODU/NEMODU/Screen/Mypage/Cell/MyRecordListTVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/Cell/MyRecordListTVC.swift
@@ -88,7 +88,19 @@ extension MyRecordListTVC {
     
     func configureCell(with element: ActivityRecord) {
         recordID = element.recordID
-        dateLabel.text = element.started
-        recordDataLabel.text = "\(element.matrixNumber.insertComma)칸 / \(element.stepCount.insertComma)보 / \(element.distance.toKilometer) / \(element.exerciseTime)"
+        
+        let date = element.started.toDate(.withTime)
+        dateLabel.text = "\(date.month)월 \(date.day)일 \(date.getDayOfWeek())요일 \(date.hour.showTwoDigitNumber):\(date.minute.showTwoDigitNumber)"
+        
+        let h = element.exerciseSecond / 3600
+        let m = (element.exerciseSecond % 3600) / 60
+        let s = (element.exerciseSecond % 3600) % 60
+        let time = (hour: h == 0 ? "" : "\(h)시간 ",
+                    minute: m == 0 ? "" : "\(m)분 ",
+                    second: "\(s)초")
+        
+        let exerciseTime = "\(time.hour)\(time.minute)\(time.second)"
+        
+        recordDataLabel.text = "\(element.matrixNumber.insertComma)칸 / \(element.stepCount.insertComma)보 / \(element.distance.toKilometer) / \(exerciseTime)"
     }
 }

--- a/NEMODU/NEMODU/Screen/Mypage/Cell/MyRecordListTVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/Cell/MyRecordListTVC.swift
@@ -90,17 +90,9 @@ extension MyRecordListTVC {
         recordID = element.recordID
         
         let date = element.started.toDate(.withTime)
-        dateLabel.text = "\(date.month)월 \(date.day)일 \(date.getDayOfWeek())요일 \(date.hour.showTwoDigitNumber):\(date.minute.showTwoDigitNumber)"
+        dateLabel.text = "\(date.month)월 \(date.day)일 \(date.getDayOfWeek())요일 \(date.toTime(.hourClock24))"
         
-        let h = element.exerciseSecond / 3600
-        let m = (element.exerciseSecond % 3600) / 60
-        let s = (element.exerciseSecond % 3600) % 60
-        let time = (hour: h == 0 ? "" : "\(h)시간 ",
-                    minute: m == 0 ? "" : "\(m)분 ",
-                    second: "\(s)초")
-        
-        let exerciseTime = "\(time.hour)\(time.minute)\(time.second)"
-        
+        let exerciseTime = element.exerciseSecond / 60 > 0 ? "\(element.exerciseSecond / 60)분" : "\(element.exerciseSecond)초"
         recordDataLabel.text = "\(element.matrixNumber.insertComma)칸 / \(element.stepCount.insertComma)보 / \(element.distance.toKilometer) / \(exerciseTime)"
     }
 }

--- a/NEMODU/NEMODU/Screen/Mypage/Model/Response/DetailRecordDataResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/Model/Response/DetailRecordDataResponseModel.swift
@@ -10,8 +10,8 @@ import Foundation
 struct DetailRecordDataResponseModel: Codable {
     let recordId: Int
     let date, started, ended: String
-    let matrixNumber, stepCount, distance: Int
-    let exerciseTime, message: String
+    let matrixNumber, stepCount, distance, exerciseTime: Int
+    let message: String
     let matrices: [Matrix]
     let challenges: [ChallengeElementResponseModel]
 }

--- a/NEMODU/NEMODU/Screen/Mypage/Model/Response/MyRecordListResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/Model/Response/MyRecordListResponseModel.swift
@@ -12,11 +12,16 @@ struct MyRecordListResponseModel: Codable {
 }
 
 struct ActivityRecord: Codable {
-    let recordID, matrixNumber, stepCount, distance: Int
-    let exerciseTime, started: String
+    let recordID: Int
+    let matrixNumber: Int
+    let stepCount: Int
+    let distance: Int
+    let exerciseSecond: Int
+    let started: String
 
     enum CodingKeys: String, CodingKey {
         case recordID = "recordId"
-        case matrixNumber, stepCount, distance, exerciseTime, started
+        case exerciseSecond = "exerciseTime"
+        case matrixNumber, stepCount, distance, started
     }
 }

--- a/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
+++ b/NEMODU/NEMODU/Screen/Mypage/ViewController/MyRecordDetailVC.swift
@@ -211,12 +211,17 @@ extension MyRecordDetailVC {
     }
     
     private func configureRecordValue(recordData: DetailRecordDataResponseModel) {
-        recordDate.text = recordData.date
-        recordTime.text = recordData.started + "-" + recordData.ended
+        let date = recordData.date.toDate(.withTime)
+        recordDate.text = "\(date.month)월 \(date.day)일 \(date.getDayOfWeek())요일"
+        
+        let started = recordData.started.toDate(.withTime).toTime(.hourClock24)
+        let ended = recordData.ended.toDate(.withTime).toTime(.hourClock24)
+        recordTime.text = "\(started) - \(ended)"
+        
         blocksCntView.recordValue.text = "\(recordData.matrixNumber)"
         miniMap.drawMyMapAtOnce(matrices: recordData.matrices)
         recordStackView.firstView.recordValue.text = "\(recordData.distance.toKilometer)"
-        recordStackView.secondView.recordValue.text = recordData.exerciseTime
+        recordStackView.secondView.recordValue.text = recordData.exerciseTime.toExerciseTime
         recordStackView.thirdView.recordValue.text = "\(recordData.stepCount)".insertComma
         memoTextView.isHidden = recordData.message == ""
         memoTextView.tv.text = recordData.message


### PR DESCRIPTION
## PR 요약
네모두는 운동 시간 기록을 60분이 넘어도 분:초 표현을 유지하고 분은 m, 초는 ss형태로 표현합니다. 
운동 시간은 초 단위로 기록되기에 Int의 extension으로 해당 부분을 일관적으로 구현할 수 있도록 변경하였습니다.

Date에서 시간을 추출할 수 있는 메서드를 추가하였습니다. DateType를 파라미터로 호출하시면 됩니다.
DateType 추가
- 24시간제 시간: hourClock24
- 12시간제 시간: hourClock12

## 변경 사항
- 시간 관련 처리가 상당히 헷갈려서 하나로 묶어버렸습니다. 어차피 통일성있게 처리될 것이고 디자인이나 기획적으로 바뀌면 해당 함수만 바꿀 수 있도록!
- 서버 모델 변경에 따라 통신 모델 변경 및 적용하였습니다.

##  ScreenShot


#### Linked Issue
close #183 

