### PR TITLE
FIX/#179 챌린지 관련 기능 점검

### DIFF
--- a/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/ChallengeHistoryDetailResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/ChallengeHistoryDetailResponseModel.swift
@@ -17,7 +17,7 @@ struct ChallengeHistoryDetailResponseModel: Codable {
     let distance: Int
     let exerciseTime: Int
     let stepCount: Int
-    let latitude, longitude: Double
+    let latitude, longitude: Double?
     let matrices: [Matrix]
     let rankings: [Ranking]
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeDetail/ChallengeHistoryDetailVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeDetail/ChallengeHistoryDetailVC.swift
@@ -319,6 +319,8 @@ extension ChallengeHistoryDetailVC {
                 $0.delegate = self
                 $0.dataSource = self
                 
+                $0.rowHeight = 84.0
+                
                 $0.register(RankingUserTVC.self, forCellReuseIdentifier: RankingUserTVC.className)
                 
                 $0.isScrollEnabled = false
@@ -515,19 +517,6 @@ extension ChallengeHistoryDetailVC : UITableViewDelegate {
         return .leastNormalMagnitude
     }
 
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return .leastNormalMagnitude
-    }
-
-    // Cell
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 84
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 84
-    }
-    
     // FooterView
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let fakeView = UIView()
@@ -539,11 +528,7 @@ extension ChallengeHistoryDetailVC : UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return .leastNormalMagnitude
     }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-        return .leastNormalMagnitude
-    }
-    
+ 
 }
 
 // MARK: - Input

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeDetail/ChallengeHistoryDetailVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeDetail/ChallengeHistoryDetailVC.swift
@@ -222,7 +222,12 @@ extension ChallengeHistoryDetailVC {
         
         let startDate = dateFormatter.string(from: .now)
         
-        let currentDayNum = calendar.component(.weekday, from: startDate.toDate(.withTime))
+        var currentDayNum = calendar.component(.weekday, from: startDate.toDate(.withTime))
+        // 일요일일 경우 D-Day 계산을 위한 값 보정
+        if currentDayNum == 1 {
+            currentDayNum = 8
+        }
+        
         let toGoSundayNum = 8 - currentDayNum
         let sundayDate = calendar.date(byAdding: .day, value: toGoSundayNum, to: startDate.toDate(.withTime)) ?? startDate.toDate(.withTime)
         
@@ -233,7 +238,7 @@ extension ChallengeHistoryDetailVC {
         progressBlackBarStackView.snp.makeConstraints {
             let bar = (progressBarStackView.frame.size.width - 6.0) / 7
             let pastDay = 7 - toGoSundayNum
-            let spaceBetweenBar = pastDay == 7 ? 0 : pastDay-1;
+            let spaceBetweenBar = pastDay == 7 ? 6 : pastDay-1;
             let length = (Int(bar) * pastDay) + (1 * spaceBetweenBar)
             
             $0.width.equalTo(length)

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeDetail/InvitedChallengeDetailVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeDetail/InvitedChallengeDetailVC.swift
@@ -61,6 +61,8 @@ class InvitedChallengeDetailVC: ChallengeDetailVC {
                 $0.delegate = self
                 $0.dataSource = self
                 
+                $0.rowHeight = 64.0
+                
                 $0.register(InvitedChallengeDetailTVHV.self, forHeaderFooterViewReuseIdentifier: InvitedChallengeDetailTVHV.className)
                 $0.register(InvitedFriendsTVC.self, forCellReuseIdentifier: InvitedFriendsTVC.className)
                 $0.register(NoListStatusTVFV.self, forHeaderFooterViewReuseIdentifier: NoListStatusTVFV.className)
@@ -116,19 +118,6 @@ extension InvitedChallengeDetailVC : UITableViewDelegate {
         return UITableView.automaticDimension
     }
 
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
-    }
-
-    // Cell
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 64
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 64
-    }
-    
 }
 
 // MARK: - Output

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeListTypeMenuBarCV.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeListTypeMenuBarCV.swift
@@ -13,14 +13,14 @@ class ChallengeListTypeMenuBarCV : ListTypeMenuBarCV {
     
     // MARK: - Variables and Properties
     
-    var challengeContainerCVC: ChallengeVC?
+    var challengeVC: ChallengeVC?
     
     // MARK: - Life Cycle
     
     override func layoutSubviews() {
         // 최초 실행시 선택되어 있는 위치 지정
         _ = menuBarCollectionView.then {
-            let indexPath = IndexPath(item: challengeContainerCVC?.reloadCellIndex ?? 0, section: 0)
+            let indexPath = IndexPath(item: challengeVC?.reloadCellIndex ?? 0, section: 0)
             $0.selectItem(at: indexPath, animated: false, scrollPosition: .left)
         }
     }
@@ -33,7 +33,7 @@ class ChallengeListTypeMenuBarCV : ListTypeMenuBarCV {
 extension ChallengeListTypeMenuBarCV {
     
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        challengeContainerCVC?.getChallengeList(index: indexPath.item)
+        challengeVC?.reloadChallengeTableView(toMoveIndex: indexPath.item)
     }
     
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeListTVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/Cell/ChallengeListTVC.swift
@@ -29,7 +29,7 @@ class ChallengeListTVC : BaseTableViewCell {
     
     private let challengeTypeLabel = UILabel()
         .then {
-            $0.text = "종류"
+            $0.text = "--"
             $0.font = .caption1
             $0.textColor = .main
             $0.backgroundColor = .clear
@@ -56,11 +56,11 @@ class ChallengeListTVC : BaseTableViewCell {
     private let challengeNameImageView = UIImageView()
         .then {
             $0.image = UIImage(named: "badge_flag")?.withRenderingMode(.alwaysTemplate)
-            $0.tintColor = ChallengeColorType.pink.primaryColor
+            $0.tintColor = ChallengeColorType.green.primaryColor
         }
     private let challengeNameLabel = UILabel()
         .then {
-            $0.text = "챌린지 이름"
+            $0.text = "----"
             $0.font = .body3
             $0.textColor = .gray900
         }
@@ -81,6 +81,17 @@ class ChallengeListTVC : BaseTableViewCell {
     // MARK: - Variables and Properties
     
     // MARK: - Life Cycle
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        challengeTypeLabel.text = "--"
+        challengeTermLabel.text = "00.00(-) - 00.00(-)"
+        challengeNameImageView.tintColor = ChallengeColorType.green.primaryColor
+        challengeNameLabel.text = "----"
+        currentStateLabel.text = "----"
+        currentJoinUserLabel.text = "-/-"
+    }
     
     override func configureView() {
         super.configureView()

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/HV/ChallengeListTVHV.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeTV/HV/ChallengeListTVHV.swift
@@ -50,14 +50,14 @@ class ChallengeListTVHV : ChallengeTitleTVHV {
             $0.horizontalEdges.equalTo(contentView)
         }
         containerView.snp.remakeConstraints {
-            $0.height.equalTo(containerViewHeight)
+            $0.height.equalTo(containerViewHeight).priority(.high)
             
             $0.top.equalTo(spaceView.snp.bottom)
             $0.horizontalEdges.equalTo(spaceView)
         }
         
         challengeListTypeMenuBar.snp.makeConstraints {
-            $0.height.equalTo(64)
+            $0.height.equalTo(64).priority(.high)
 
             $0.top.equalTo(containerView.snp.bottom)
             $0.horizontalEdges.equalTo(containerView)

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
@@ -51,14 +51,12 @@ class ChallengeVC : BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        viewModel.getWaitChallengeList()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        viewModel.getInvitedChallengeList()
+        getChallengeList()
     }
     
     override func configureView() {
@@ -89,22 +87,25 @@ class ChallengeVC : BaseViewController {
 
     // MARK: - Functions
     
-    func getChallengeList(index: Int) {
-        switch index {
-        case 0:
-            viewModel.getWaitChallengeList()
-        case 1:
-            viewModel.getProgressChallengeList()
-        case 2:
-            viewModel.getDoneChallengeList()
-        default:
-            break
-        }
+    private func getChallengeList() {
+        // 초대받은 챌린지
+        viewModel.getInvitedChallengeList()
+        
+        // 챌린지 내역
+        viewModel.getWaitChallengeList()
+        viewModel.getProgressChallengeList()
+        viewModel.getDoneChallengeList()
     }
     
     func reloadChallengeTableView(toMoveIndex: Int) {
+        let curIndex = reloadCellIndex
         reloadCellIndex = toMoveIndex
-        challengeTableView.reloadSections(IndexSet(2...2), with: .fade)
+        
+        if toMoveIndex == curIndex {
+            challengeTableView.reloadSections(IndexSet(2...2), with: .none)
+        } else {
+            challengeTableView.reloadSections(IndexSet(2...2), with: toMoveIndex < curIndex ? .right : .left)
+        }
     }
     
 }
@@ -253,8 +254,7 @@ extension ChallengeVC : UITableViewDelegate {
         case 1:
             headerId = ChallengeListTVHV.className
             let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerId) as? ChallengeListTVHV
-            
-            headerView?.challengeListTypeMenuBar.challengeContainerCVC = self
+            headerView?.challengeListTypeMenuBar.challengeVC = self
             
             return headerView
         case 2:
@@ -437,7 +437,6 @@ extension ChallengeVC {
                 guard let self = self else { return }
                 
                 self.waitChallengeListResponseModel = data
-                self.reloadChallengeTableView(toMoveIndex: 0)
             })
             .disposed(by: disposeBag)
         
@@ -446,7 +445,6 @@ extension ChallengeVC {
                 guard let self = self else { return }
                 
                 self.progressChallengeListResponseModel = data
-                self.reloadChallengeTableView(toMoveIndex: 1)
             })
             .disposed(by: disposeBag)
         
@@ -455,7 +453,6 @@ extension ChallengeVC {
                 guard let self = self else { return }
                 
                 self.doneChallengeListResponseModel = data
-                self.reloadChallengeTableView(toMoveIndex: 2)
             })
             .disposed(by: disposeBag)
     }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
@@ -89,13 +89,29 @@ class ChallengeVC : BaseViewController {
     // MARK: - Functions
     
     private func getChallengeList() {
-        // 초대받은 챌린지
-        viewModel.getInvitedChallengeList()
-        
-        // 챌린지 내역
-        viewModel.getWaitChallengeList()
-        viewModel.getProgressChallengeList()
-        viewModel.getDoneChallengeList()
+        DispatchQueue.global().sync {
+            let beforeCntInvited = invitedChallengeListResponseModel?.count
+            let beforeCntWait = waitChallengeListResponseModel?.count
+            let beforeCntProgress = progressChallengeListResponseModel?.count
+            let beforeCntDone = doneChallengeListResponseModel?.count
+
+            // 초대받은 챌린지
+            viewModel.getInvitedChallengeList()
+            
+            // 챌린지 내역
+            viewModel.getWaitChallengeList()
+            viewModel.getProgressChallengeList()
+            viewModel.getDoneChallengeList()
+
+            if invitedChallengeListResponseModel?.count != beforeCntInvited ||
+                waitChallengeListResponseModel?.count != beforeCntWait ||
+                progressChallengeListResponseModel?.count != beforeCntProgress ||
+                doneChallengeListResponseModel?.count != beforeCntDone {
+                challengeTableView.reloadData()
+            } else {
+                reloadChallengeTableView(toMoveIndex: reloadCellIndex)
+            }
+        }
     }
     
     func reloadChallengeTableView(toMoveIndex: Int) {
@@ -103,7 +119,7 @@ class ChallengeVC : BaseViewController {
         reloadCellIndex = toMoveIndex
         
         if toMoveIndex == curIndex {
-            challengeTableView.reloadSections(IndexSet(2...2), with: .none)
+            challengeTableView.reloadData()
         } else {
             challengeTableView.reloadSections(IndexSet(2...2), with: toMoveIndex < curIndex ? .right : .left)
         }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
@@ -406,11 +406,12 @@ extension ChallengeVC {
         createChallengeButton.rx.tap
             .asDriver()
             .drive(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                
                 let selectChallengeCreateVC = SelectChallengeCreateVC()
                 selectChallengeCreateVC.hidesBottomBarWhenPushed = true
                 
-                let rootViewController = self?.view.superview?.findViewController()
-                rootViewController?.navigationController?.pushViewController(selectChallengeCreateVC, animated: true)
+                self.navigationController?.pushViewController(selectChallengeCreateVC, animated: true)
             })
             .disposed(by: disposeBag)
     }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
@@ -20,6 +20,7 @@ class ChallengeVC : BaseViewController {
             $0.separatorStyle = .none
             $0.backgroundColor = .white
             $0.showsVerticalScrollIndicator = false
+            $0.rowHeight = 116.0
         }
     
     private lazy var createChallengeButton = UIButton().then {
@@ -275,10 +276,6 @@ extension ChallengeVC : UITableViewDelegate {
         section == 2 ? .leastNormalMagnitude : UITableView.automaticDimension
     }
 
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        section == 2 ? .leastNormalMagnitude : UITableView.automaticDimension
-    }
-
     // Cell
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch indexPath.section {
@@ -321,14 +318,6 @@ extension ChallengeVC : UITableViewDelegate {
         }
     }
     
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 116
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 116
-    }
-
     // FooterView
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         var message = ""
@@ -375,28 +364,6 @@ extension ChallengeVC : UITableViewDelegate {
         }
     }
 
-    func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-        switch section {
-        case 0: // 초대받은 챌린지
-            return invitedChallengeListResponseModel?.count ?? 0 == 0 ? 93 : .leastNormalMagnitude
-        case 1: // 챌린지 내역 및 메뉴바
-            return .leastNormalMagnitude
-        case 2: // 챌린지 목록
-            switch reloadCellIndex {
-            case 0: // 진행 대기중
-                return waitChallengeListResponseModel?.count ?? 0 == 0 ? 93 : .leastNormalMagnitude
-            case 1: // 진행 중
-                return progressChallengeListResponseModel?.count ?? 0 == 0 ? 93 : .leastNormalMagnitude
-            case 2: // 진행 완료
-                return doneChallengeListResponseModel?.count ?? 0 == 0 ? 93 : .leastNormalMagnitude
-            default:
-                return 93
-            }
-        default:
-            return 93
-        }
-    }
-    
 }
 
 // MARK: - Input

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
@@ -141,7 +141,6 @@ extension ChallengeVC {
                 // footerView
                 $0.register(NoListStatusTVFV.self, forHeaderFooterViewReuseIdentifier: NoListStatusTVFV.className)
                 
-                
                 // footerView 하단 여백이 생기는 것을 방지(tableView 내의 scrollView의 inset 값 때문인 것으로 추정)
                 $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: -20, right: 0)
             }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/SelectFriendsVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/SelectFriendsVC.swift
@@ -103,7 +103,7 @@ class SelectFriendsVC: CreateChallengeVC {
     var createWeekChallengeVC: CreateWeekChallengeVC?
     
     private let viewModel = SelectFriendsVM()
-    private var friendsListResponseModel: FriendsListResponseModel?
+    private var friendsListResponseModel: [FriendDefaultInfo]?
     
     private var selectedFriendsList: [FriendDefaultInfo] = []
     
@@ -114,7 +114,7 @@ class SelectFriendsVC: CreateChallengeVC {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        viewModel.getFriendsList(offset: 0)
+        viewModel.getFriendsList(size: 15)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -231,8 +231,8 @@ class SelectFriendsVC: CreateChallengeVC {
         guard let friendsList = friendsListResponseModel else { return }
         
         var targetIndex = 3
-        for i in 0..<friendsList.infos.count {
-            if friendsList.infos[i].nickname == selectedFriendsList[sender.tag].nickname {
+        for i in 0..<friendsList.count {
+            if friendsList[i].nickname == selectedFriendsList[sender.tag].nickname {
                 targetIndex = i
                 break
             }
@@ -382,7 +382,7 @@ extension SelectFriendsVC : UITableViewDataSource {
             return UITableViewCell()
         }
         guard let friendsList = friendsListResponseModel else { return UITableViewCell() }
-        cell.configureSelectFriendsTVC(friendInfo: friendsList.infos[indexPath.row])
+        cell.configureSelectFriendsTVC(friendInfo: friendsList[indexPath.row])
         
         return cell
     }
@@ -395,7 +395,7 @@ extension SelectFriendsVC : UITableViewDelegate {
     
     // Cell
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return friendsListResponseModel?.infos.count ?? 0
+        return friendsListResponseModel?.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -411,7 +411,7 @@ extension SelectFriendsVC : UITableViewDelegate {
         cell.didTapCheck()
         
         guard let friendsList = friendsListResponseModel else { return }
-        showSelectedFriend(friendInfo: friendsList.infos[indexPath.row])
+        showSelectedFriend(friendInfo: friendsList[indexPath.row])
         
         updateLimitFriendsCountLabel()
         checkConfirmButtonEnable()
@@ -422,7 +422,7 @@ extension SelectFriendsVC : UITableViewDelegate {
         cell.didTapCheck()
         
         guard let friendsList = friendsListResponseModel else { return }
-        deleteSelectedFriend(friendInfo: friendsList.infos[indexPath.row])
+        deleteSelectedFriend(friendInfo: friendsList[indexPath.row])
 
         updateLimitFriendsCountLabel()
         checkConfirmButtonEnable()
@@ -443,12 +443,12 @@ extension SelectFriendsVC : UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         guard let friendsList = friendsListResponseModel else { return 93 }
-        return friendsList.infos.count == 0 ? 93 : .leastNormalMagnitude
+        return friendsList.count == 0 ? 93 : .leastNormalMagnitude
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
         guard let friendsList = friendsListResponseModel else { return 93 }
-        return friendsList.infos.count == 0 ? 93 : .leastNormalMagnitude
+        return friendsList.count == 0 ? 93 : .leastNormalMagnitude
     }
     
 }
@@ -489,7 +489,7 @@ extension SelectFriendsVC {
 extension SelectFriendsVC {
     
     private func responseFriendsList() {
-        viewModel.output.successWithResponseData
+        viewModel.output.friendsList
             .subscribe(onNext: { [weak self] data in
                 guard let self = self else { return }
                 

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/SelectFriendsVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/SelectFriendsVC.swift
@@ -96,6 +96,7 @@ class SelectFriendsVC: CreateChallengeVC {
         .then {
             $0.separatorStyle = .none
             $0.allowsMultipleSelection = true
+            $0.rowHeight = UITableView.automaticDimension
         }
     
     // MARK: - Variables and Properties
@@ -397,15 +398,7 @@ extension SelectFriendsVC : UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return friendsListResponseModel?.count ?? 0
     }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
-    }
-
+   
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let cell = tableView.cellForRow(at: indexPath) as? SelectFriendsTVC else { return }
         cell.didTapCheck()
@@ -445,12 +438,7 @@ extension SelectFriendsVC : UITableViewDelegate {
         guard let friendsList = friendsListResponseModel else { return 93 }
         return friendsList.count == 0 ? 93 : .leastNormalMagnitude
     }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-        guard let friendsList = friendsListResponseModel else { return 93 }
-        return friendsList.count == 0 ? 93 : .leastNormalMagnitude
-    }
-    
+   
 }
 
 // MARK: - Input

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/AccumulateRankingListVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/AccumulateRankingListVC.swift
@@ -114,34 +114,9 @@ extension AccumulateRankingListVC : UITableViewDelegate {
             return fakeView
     }
 
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 24
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return 24
-    }
-    
     // Cell
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return accumulateRankingListResponseModel?.matrixRankings.count ?? 0
-    }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 84
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 84
-    }
-
-    // FooterView
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return .leastNormalMagnitude
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-        return .leastNormalMagnitude
     }
     
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/AreaRankingListVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/AreaRankingListVC.swift
@@ -113,34 +113,9 @@ extension AreaRankingListVC : UITableViewDelegate {
             return fakeView
     }
 
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 24
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return 24
-    }
-    
     // Cell
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return areaRankingListResponseModel?.areaRankings.count ?? 0
-    }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 84
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 84
-    }
-
-    // FooterView
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return .leastNormalMagnitude
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-        return .leastNormalMagnitude
     }
     
 }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/RankingListVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/RankingListVC.swift
@@ -47,6 +47,10 @@ class RankingListVC : BaseViewController {
             $0.showsVerticalScrollIndicator = false
             
             $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: -20, right: 0)
+            
+            $0.sectionHeaderHeight = 24.0
+            $0.rowHeight = 84.0
+            $0.sectionFooterHeight = .leastNormalMagnitude
         }
         
     // MARK: - Variables and Properties

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/StepRankingListVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Ranking/StepRankingListVC.swift
@@ -115,34 +115,9 @@ extension StepRankingListVC : UITableViewDelegate {
             return fakeView
     }
 
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 24
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return 24
-    }
-    
     // Cell
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return stepRankingListResponseModel?.stepRankings.count ?? 0
-    }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 84
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 84
-    }
-
-    // FooterView
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return .leastNormalMagnitude
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-        return .leastNormalMagnitude
     }
     
 }


### PR DESCRIPTION
## PR 요약
-  챌린지 목록(진행 대기중, 진행 중, 진행완료) 셀 재사용 문제점을 점검
-  챌린지 생성 버튼바인딩 내부 NavigationController 호출 방식을 변경(rootViewController -> self) 및 guard let self 구문 추가
-  챌린지 목록 서버코드 호출 시점을 viewWillApear로 변경
-  챌린지 관련 테이블뷰 (고정된) height 관련 델리게이트 호출 코드 제거
-  진행 중인 챌린지 상세페이지 d-day 표시 오류(ex. 14일날 14일까지 진행하는 챌린지 조회 시 0으로 표기되는 문제) 수정
-  챌린지 생성 - 친구 목록 불러오는 서버 코드 리스펀스 값 변경 대응
-  챌린지 상세보기에 latitude, longtitude 값이 null일 경우 리스펀스 값을 해석하지 못하는 문제 대응

## 변경 사항

##  ScreenShot

#### Linked Issue
close #179
