### PR TITLE
fix/#213 챌린지 생성 요청 시 챌린지 시작시간 변경

### DIFF
--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateChallengeSuccuessVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateChallengeSuccuessVC.swift
@@ -15,6 +15,14 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
     
     // MARK: - UI components
     
+    private let baseContainerView = UIView()
+    private let contentStackView = UIStackView()
+        .then {
+            $0.axis = .vertical
+            $0.spacing = 20
+            $0.alignment = .center
+        }
+    
     private let successTitleLabel = PaddingLabel()
         .then {
             $0.text = "주간 챌린지가 \n만들어졌습니다!"
@@ -38,12 +46,13 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
             $0.backgroundColor = .gray50
             $0.layer.cornerRadius = 16
         }
-    
     private let challengeTitleLabel = PaddingLabel()
         .then {
             $0.text = "----"
-            $0.font = .body1
             $0.textColor = .gray900
+            $0.font = .body1
+            $0.textAlignment = .center
+            $0.setLineBreakMode()
             
             $0.backgroundColor = .clear
         }
@@ -183,26 +192,28 @@ extension CreateChallengeSuccuessVC {
 extension CreateChallengeSuccuessVC {
     
     private func configureLayout() {
-        view.addSubviews([successTitleLabel, successIconImageView, informationContainerView])
+        view.addSubviews([baseContainerView])
+        baseContainerView.addSubviews([contentStackView])
+        [successTitleLabel, successIconImageView, informationContainerView].forEach {
+            contentStackView.addArrangedSubview($0)
+        }
         informationContainerView.addSubviews([challengeTitleLabel, challengeDateLabel, userProfileStackView, separateView, explainLabel])
         
-        
-        successTitleLabel.snp.makeConstraints {
-            $0.centerX.equalTo(view)
-            $0.top.lessThanOrEqualTo(navigationBar.snp.bottom).offset(60)
+        baseContainerView.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.horizontalEdges.equalTo(view)
+            $0.bottom.equalTo(confirmButton.snp.top)
         }
+        contentStackView.snp.makeConstraints {
+            $0.centerY.horizontalEdges.equalTo(baseContainerView)
+        }
+        
         successIconImageView.snp.makeConstraints {
             $0.width.height.equalTo(102)
-            
-            $0.centerX.equalTo(successTitleLabel)
-            $0.top.equalTo(successTitleLabel.snp.bottom).offset(36)
         }
         
         informationContainerView.snp.makeConstraints {
             $0.width.equalTo(343)
-            
-            $0.centerX.equalTo(successIconImageView)
-            $0.top.equalTo(successIconImageView.snp.bottom).offset(36)
         }
         challengeTitleLabel.snp.makeConstraints {
             $0.centerX.equalTo(informationContainerView)

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateChallengeSuccuessVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateChallengeSuccuessVC.swift
@@ -15,14 +15,6 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
     
     // MARK: - UI components
     
-    private let baseContainerView = UIView()
-    private let contentStackView = UIStackView()
-        .then {
-            $0.axis = .vertical
-            $0.spacing = 20
-            $0.alignment = .center
-        }
-    
     private let successTitleLabel = PaddingLabel()
         .then {
             $0.text = "주간 챌린지가 \n만들어졌습니다!"
@@ -46,13 +38,12 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
             $0.backgroundColor = .gray50
             $0.layer.cornerRadius = 16
         }
+    
     private let challengeTitleLabel = PaddingLabel()
         .then {
             $0.text = "----"
-            $0.textColor = .gray900
             $0.font = .body1
-            $0.textAlignment = .center
-            $0.setLineBreakMode()
+            $0.textColor = .gray900
             
             $0.backgroundColor = .clear
         }
@@ -192,28 +183,26 @@ extension CreateChallengeSuccuessVC {
 extension CreateChallengeSuccuessVC {
     
     private func configureLayout() {
-        view.addSubviews([baseContainerView])
-        baseContainerView.addSubviews([contentStackView])
-        [successTitleLabel, successIconImageView, informationContainerView].forEach {
-            contentStackView.addArrangedSubview($0)
-        }
+        view.addSubviews([successTitleLabel, successIconImageView, informationContainerView])
         informationContainerView.addSubviews([challengeTitleLabel, challengeDateLabel, userProfileStackView, separateView, explainLabel])
         
-        baseContainerView.snp.makeConstraints {
-            $0.top.equalTo(navigationBar.snp.bottom)
-            $0.horizontalEdges.equalTo(view)
-            $0.bottom.equalTo(confirmButton.snp.top)
-        }
-        contentStackView.snp.makeConstraints {
-            $0.centerY.horizontalEdges.equalTo(baseContainerView)
-        }
         
+        successTitleLabel.snp.makeConstraints {
+            $0.centerX.equalTo(view)
+            $0.top.lessThanOrEqualTo(navigationBar.snp.bottom).offset(60)
+        }
         successIconImageView.snp.makeConstraints {
             $0.width.height.equalTo(102)
+            
+            $0.centerX.equalTo(successTitleLabel)
+            $0.top.equalTo(successTitleLabel.snp.bottom).offset(36)
         }
         
         informationContainerView.snp.makeConstraints {
             $0.width.equalTo(343)
+            
+            $0.centerX.equalTo(successIconImageView)
+            $0.top.equalTo(successIconImageView.snp.bottom).offset(36)
         }
         challengeTitleLabel.snp.makeConstraints {
             $0.centerX.equalTo(informationContainerView)

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
@@ -455,6 +455,19 @@ extension CreateWeekChallengeVC {
     }
     
     private func bindInsertChallengeMessageTextView() {
+        insertChallengeMessageTextView.tv.rx.text
+            .asDriver()
+            .drive(onNext: { [weak self] text in
+                guard let self = self,
+                let text = text else { return }
+                
+                let lines = text.components(separatedBy: .newlines)
+                if lines.count > 4 {
+                    self.insertChallengeMessageTextView.tv.text.removeLast()
+                }
+            })
+            .disposed(by: disposeBag)
+                
         insertChallengeMessageTextView.tv.rx.didBeginEditing
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
@@ -455,19 +455,6 @@ extension CreateWeekChallengeVC {
     }
     
     private func bindInsertChallengeMessageTextView() {
-        insertChallengeMessageTextView.tv.rx.text
-            .asDriver()
-            .drive(onNext: { [weak self] text in
-                guard let self = self,
-                let text = text else { return }
-                
-                let lines = text.components(separatedBy: .newlines)
-                if lines.count > 4 {
-                    self.insertChallengeMessageTextView.tv.text.removeLast()
-                }
-            })
-            .disposed(by: disposeBag)
-                
         insertChallengeMessageTextView.tv.rx.didBeginEditing
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
@@ -182,10 +182,10 @@ class CreateWeekChallengeVC: CreateChallengeVC {
             friendsNickname.append(friend.nickname)
         }
         
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .medium
-        dateFormatter.dateFormat = DateType.withTime.dateFormatter
-        let challengeStart = dateFormatter.string(from: startedDate ?? .now)
+        var challengeStart: String = ""
+        if let startDate = startedDate {
+            challengeStart = "\(startDate.year)-\(startDate.month.showTwoDigitNumber)-\(startDate.day.showTwoDigitNumber)T00:00:00"
+        }
         
         viewModel.requestCreateWeekChallengeVM(with: CreateChallengeRequestModel(friends: friendsNickname, message: challengeMessage, name: challengeName, nickname: myNickname, started: challengeStart, type: type))
     }


### PR DESCRIPTION
## PR 요약
챌린지 생성 시 챌린지 시작시간이 생성 시점(ex.2023:05:26T**17:35:12**)으로 잘못 설정해 서버측에서 챌린지가 진행 중으로 넘어가지 않는 문제를 수정하기 위해 올바른 요청인 00:00:00으로(ex.2023:05:26T**00:00:00**) 설정해서 요청을 보내는 방식으로 수정

## 변경 사항
- 브랜치를 착각하여 다른 내용의 커밋을 작성하다 revert하였습니다. Revert 이전 커밋만 참고 부탁드립니다!

##  ScreenShot

#### Linked Issue
close #213

