### PR TITLE
fix/#186 기기화면 대응 점검

### DIFF
--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateChallengeSuccuessVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateChallengeSuccuessVC.swift
@@ -15,6 +15,14 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
     
     // MARK: - UI components
     
+    private let baseContainerView = UIView()
+    private let contentStackView = UIStackView()
+        .then {
+            $0.axis = .vertical
+            $0.spacing = 20
+            $0.alignment = .center
+        }
+    
     private let successTitleLabel = PaddingLabel()
         .then {
             $0.text = "주간 챌린지가 \n만들어졌습니다!"
@@ -38,12 +46,13 @@ class CreateChallengeSuccuessVC: CreateChallengeVC {
             $0.backgroundColor = .gray50
             $0.layer.cornerRadius = 16
         }
-    
     private let challengeTitleLabel = PaddingLabel()
         .then {
             $0.text = "----"
-            $0.font = .body1
             $0.textColor = .gray900
+            $0.font = .body1
+            $0.textAlignment = .center
+            $0.setLineBreakMode()
             
             $0.backgroundColor = .clear
         }
@@ -183,26 +192,28 @@ extension CreateChallengeSuccuessVC {
 extension CreateChallengeSuccuessVC {
     
     private func configureLayout() {
-        view.addSubviews([successTitleLabel, successIconImageView, informationContainerView])
+        view.addSubviews([baseContainerView])
+        baseContainerView.addSubviews([contentStackView])
+        [successTitleLabel, successIconImageView, informationContainerView].forEach {
+            contentStackView.addArrangedSubview($0)
+        }
         informationContainerView.addSubviews([challengeTitleLabel, challengeDateLabel, userProfileStackView, separateView, explainLabel])
         
-        
-        successTitleLabel.snp.makeConstraints {
-            $0.centerX.equalTo(view)
-            $0.top.lessThanOrEqualTo(navigationBar.snp.bottom).offset(60)
+        baseContainerView.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.horizontalEdges.equalTo(view)
+            $0.bottom.equalTo(confirmButton.snp.top)
         }
+        contentStackView.snp.makeConstraints {
+            $0.centerY.horizontalEdges.equalTo(baseContainerView)
+        }
+        
         successIconImageView.snp.makeConstraints {
             $0.width.height.equalTo(102)
-            
-            $0.centerX.equalTo(successTitleLabel)
-            $0.top.equalTo(successTitleLabel.snp.bottom).offset(36)
         }
         
         informationContainerView.snp.makeConstraints {
             $0.width.equalTo(343)
-            
-            $0.centerX.equalTo(successIconImageView)
-            $0.top.equalTo(successIconImageView.snp.bottom).offset(36)
         }
         challengeTitleLabel.snp.makeConstraints {
             $0.centerX.equalTo(informationContainerView)

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/CreateChallenge/CreateWeekChallenge/CreateWeekChallengeVC.swift
@@ -182,10 +182,10 @@ class CreateWeekChallengeVC: CreateChallengeVC {
             friendsNickname.append(friend.nickname)
         }
         
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .medium
-        dateFormatter.dateFormat = DateType.withTime.dateFormatter
-        let challengeStart = dateFormatter.string(from: startedDate ?? .now)
+        var challengeStart: String = ""
+        if let startDate = startedDate {
+            challengeStart = "\(startDate.year)-\(startDate.month.showTwoDigitNumber)-\(startDate.day.showTwoDigitNumber)T00:00:00"
+        }
         
         viewModel.requestCreateWeekChallengeVM(with: CreateChallengeRequestModel(friends: friendsNickname, message: challengeMessage, name: challengeName, nickname: myNickname, started: challengeStart, type: type))
     }
@@ -455,6 +455,19 @@ extension CreateWeekChallengeVC {
     }
     
     private func bindInsertChallengeMessageTextView() {
+        insertChallengeMessageTextView.tv.rx.text
+            .asDriver()
+            .drive(onNext: { [weak self] text in
+                guard let self = self,
+                let text = text else { return }
+                
+                let lines = text.components(separatedBy: .newlines)
+                if lines.count > 4 {
+                    self.insertChallengeMessageTextView.tv.text.removeLast()
+                }
+            })
+            .disposed(by: disposeBag)
+                
         insertChallengeMessageTextView.tv.rx.didBeginEditing
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }


### PR DESCRIPTION
## PR 요약
기존 아이폰11Pro 기준 레이아웃 개발에서 아이폰SE, 아이폰 미니 등의 댜른 기기화면 사이즈의 문제점 점검
- 챌린지 성공 화면 팝업 시, 아이폰SE3(= 아이폰8)에서 레이아웃이 어긋나는 문제를 수정
## 변경 사항

##  ScreenShot
<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-7th-1-iOS/assets/26570294/9f4f34ec-ae06-454a-8247-a4688a89007b" >  <img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-7th-1-iOS/assets/26570294/24c19bed-9fd2-4ce5-a089-21b3331e2b3c" >

#### Linked Issue
close #186

