### PR TITLE
Fix/#222 누적 랭킹 목록 조회 API 수정

### DIFF
--- a/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Ranking/Response/AccumulateRankingListResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Ranking/Response/AccumulateRankingListResponseModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import Alamofire
 
 struct AccumulateRankingListResponseModel: Codable {
-    let matrixRankings: [MatrixRanking]
+    var matrixRankings: [MatrixRanking]
 }
 
 // MARK: - MatrixRanking

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/View/RankingUserView.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/View/RankingUserView.swift
@@ -131,12 +131,19 @@ extension RankingUserView {
     
     /// 기본적인 랭킹 목록 정보를 입력하는 함수
     func configureRankingUserView(rankNumber: Int, profileImageURL: URL?, nickname: String, blocksNumber: Int) {
-        rankNumberLabel.text = "\(rankNumber)"
+        var rank = String(rankNumber)
+        var score = String(blocksNumber)
+        if rankNumber == 0 {
+            rank = "-"
+            score = "-"
+        }
+        
+        rankNumberLabel.text = "\(rank)"
         userProfileImageView.kf.setImage(with: profileImageURL, placeholder: UIImage.defaultThumbnail)
         showMeLabel.isHidden = !isMyNickname(nickname: nickname)
 
         userNicknameLabel.text = nickname
-        blocksNumberLabel.text = "\(blocksNumber.insertComma)"
+        blocksNumberLabel.text = "\(score.insertComma)"
     }
     
     /// 걸음수(Step) 랭킹에 표시되는 기본 단위 설정


### PR DESCRIPTION
## PR 요약
기존 누적 랭킹 조회 API에서 자신 랭킹 API + 페이징 누적 랭킹목록로 분리된 API에 대한 수정 반영 작업을 진행하였습니다.
- **AccumulateRankingListVM**에 정의 되어있던 누적랭킹에 나의 누적랭킹 조회 API를 추가하였습니다
- 기존에 전체 목록을 불러오던 구조에서 10개씩 분리해서 테이블뷰 마지막 인덱스까지 스크롤 된 경우 추가 목록을 불러오는 구조로 변경하였습니다

## 변경 사항

##  ScreenShot

#### Linked Issue
close #222

