### PR TITLE
Fix/#223 챌린지 목록 페이징

### DIFF
--- a/NEMODU/NEMODU.xcodeproj/project.pbxproj
+++ b/NEMODU/NEMODU.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 		3C05FFEF28B74E2B0017F4E1 /* CreateChallengeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C05FFEE28B74E2B0017F4E1 /* CreateChallengeVC.swift */; };
 		3C05FFF128B794390017F4E1 /* CreateChallengeSuccuessVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C05FFF028B794390017F4E1 /* CreateChallengeSuccuessVC.swift */; };
 		3C05FFF528B7E0900017F4E1 /* SelectFriendsTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C05FFF428B7E0900017F4E1 /* SelectFriendsTVC.swift */; };
-		3C064BBD290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C064BBC290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift */; };
+		3C064BBD290F95B500522274 /* ProgressChallengeListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C064BBC290F95B500522274 /* ProgressChallengeListResponseModel.swift */; };
 		3C064BBF290FAEAB00522274 /* InvitedChallengeListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C064BBE290FAEAB00522274 /* InvitedChallengeListResponseModel.swift */; };
 		3C064BC2290FCA1400522274 /* InvitedChallengeDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C064BC1290FCA1400522274 /* InvitedChallengeDetailVC.swift */; };
 		3C064BC4290FE45600522274 /* InvitedChallengeDetailTVHV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C064BC3290FE45600522274 /* InvitedChallengeDetailTVHV.swift */; };
@@ -280,6 +280,7 @@
 		3CB9DBA628A954EE007BC1BE /* RankingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB9DBA528A954EE007BC1BE /* RankingVC.swift */; };
 		3CC1EC7328D06811007C87F6 /* CreateWidenChallengeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC1EC7228D06811007C87F6 /* CreateWidenChallengeVC.swift */; };
 		3CC1EC7528D06917007C87F6 /* CreateAccumulateChallengeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC1EC7428D06917007C87F6 /* CreateAccumulateChallengeVC.swift */; };
+		3CC2BCE12A3B585D004AA985 /* DoneChallengeListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC2BCE02A3B585D004AA985 /* DoneChallengeListResponseModel.swift */; };
 		3CCEDB5D29EFDA440047CF6E /* SetNotificationVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCEDB5C29EFDA440047CF6E /* SetNotificationVM.swift */; };
 		3CCEDB5F29EFDC470047CF6E /* SetNotificationResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCEDB5E29EFDC470047CF6E /* SetNotificationResponseModel.swift */; };
 		3CD1FFFB29DEC19F00CE4367 /* AcceptRejectChallengeResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD1FFFA29DEC19F00CE4367 /* AcceptRejectChallengeResponseModel.swift */; };
@@ -502,7 +503,7 @@
 		3C05FFEE28B74E2B0017F4E1 /* CreateChallengeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateChallengeVC.swift; sourceTree = "<group>"; };
 		3C05FFF028B794390017F4E1 /* CreateChallengeSuccuessVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateChallengeSuccuessVC.swift; sourceTree = "<group>"; };
 		3C05FFF428B7E0900017F4E1 /* SelectFriendsTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectFriendsTVC.swift; sourceTree = "<group>"; };
-		3C064BBC290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressAndDoneChallengeListResponseModel.swift; sourceTree = "<group>"; };
+		3C064BBC290F95B500522274 /* ProgressChallengeListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressChallengeListResponseModel.swift; sourceTree = "<group>"; };
 		3C064BBE290FAEAB00522274 /* InvitedChallengeListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitedChallengeListResponseModel.swift; sourceTree = "<group>"; };
 		3C064BC1290FCA1400522274 /* InvitedChallengeDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitedChallengeDetailVC.swift; sourceTree = "<group>"; };
 		3C064BC3290FE45600522274 /* InvitedChallengeDetailTVHV.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitedChallengeDetailTVHV.swift; sourceTree = "<group>"; };
@@ -583,6 +584,7 @@
 		3CB9DBA528A954EE007BC1BE /* RankingVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RankingVC.swift; sourceTree = "<group>"; };
 		3CC1EC7228D06811007C87F6 /* CreateWidenChallengeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateWidenChallengeVC.swift; sourceTree = "<group>"; };
 		3CC1EC7428D06917007C87F6 /* CreateAccumulateChallengeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccumulateChallengeVC.swift; sourceTree = "<group>"; };
+		3CC2BCE02A3B585D004AA985 /* DoneChallengeListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoneChallengeListResponseModel.swift; sourceTree = "<group>"; };
 		3CCEDB5C29EFDA440047CF6E /* SetNotificationVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNotificationVM.swift; sourceTree = "<group>"; };
 		3CCEDB5E29EFDC470047CF6E /* SetNotificationResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNotificationResponseModel.swift; sourceTree = "<group>"; };
 		3CD1FFFA29DEC19F00CE4367 /* AcceptRejectChallengeResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptRejectChallengeResponseModel.swift; sourceTree = "<group>"; };
@@ -1454,12 +1456,13 @@
 			children = (
 				3C0029F229011378001BB6AE /* CreatChallengeResponseModel.swift */,
 				3CB766BC290E773600EAE812 /* WaitChallengeListResponseModel.swift */,
-				3C064BBC290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift */,
+				3C064BBC290F95B500522274 /* ProgressChallengeListResponseModel.swift */,
 				3C064BBE290FAEAB00522274 /* InvitedChallengeListResponseModel.swift */,
 				3CF68387293CD5CA00A52521 /* ChallengeHistoryDetailResponseModel.swift */,
 				3C44DEE3294896D00039681A /* InvitedChallengeDetailResponseModel.swift */,
 				3C4E8559298CDB05001E8766 /* ChallengeDetailMapResponseModel.swift */,
 				3CD1FFFA29DEC19F00CE4367 /* AcceptRejectChallengeResponseModel.swift */,
+				3CC2BCE02A3B585D004AA985 /* DoneChallengeListResponseModel.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1888,6 +1891,7 @@
 				3C304368292F676700FAD69A /* ChallengeDetailVC.swift in Sources */,
 				2348B40D2892D360001095BC /* UIColor+.swift in Sources */,
 				23E0DD702A1E70EC0074A21E /* SearchFriendProtocol.swift in Sources */,
+				3CC2BCE12A3B585D004AA985 /* DoneChallengeListResponseModel.swift in Sources */,
 				2388B66D2A1E149F00DF75B4 /* AddNemoduFriendTVC.swift in Sources */,
 				2312200529DE5A5400928E4E /* ToggleButtonView.swift in Sources */,
 				23566E642A11034A00EBA458 /* FriendListDataSource.swift in Sources */,
@@ -1922,7 +1926,7 @@
 				2348B3FD2892D16C001095BC /* Loadable.swift in Sources */,
 				2375740528FC4856006026ED /* FriendListDefaultTVC.swift in Sources */,
 				3C4E855A298CDB05001E8766 /* ChallengeDetailMapResponseModel.swift in Sources */,
-				3C064BBD290F95B500522274 /* ProgressAndDoneChallengeListResponseModel.swift in Sources */,
+				3C064BBD290F95B500522274 /* ProgressChallengeListResponseModel.swift in Sources */,
 				2365F3B22A1CE7B900475736 /* KakaoFriendListResponseModel.swift in Sources */,
 				2348B4012892D1A6001095BC /* UITextField+.swift in Sources */,
 				3C44DEE62948A4360039681A /* InvitedChallengeAcceptType.swift in Sources */,

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/DoneChallengeListResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/DoneChallengeListResponseModel.swift
@@ -1,0 +1,15 @@
+//
+//  DoneChallengeListResponseModel.swift
+//  NEMODU
+//
+//  Created by Kim HeeJae on 2023/06/14.
+//
+
+import Foundation
+
+struct DoneChallengeListResponseModel: Codable {
+    let infos: [ProgressAndDoneChallengeListElement]
+    let size: Int
+    let isLast: Bool
+    let offset: Int?
+}

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/InvitedChallengeListResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/InvitedChallengeListResponseModel.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
+struct InvitedChallengeListResponseModel: Codable {
+    let infos: [InvitedChallengeListElement]
+    let size: Int
+    let isLast: Bool
+    let offset: Int?
+}
+
 struct InvitedChallengeListElement: Codable {
     let created, inviterNickname, message, name: String
     let picturePath, uuid: String
@@ -18,5 +25,3 @@ extension InvitedChallengeListElement {
         return URL(string: picturePathURL)
     }
 }
-
-typealias InvitedChallengeListResponseModel = [InvitedChallengeListElement]

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/ProgressChallengeListResponseModel.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/Model/Challenge/Response/ProgressChallengeListResponseModel.swift
@@ -1,5 +1,5 @@
 //
-//  ProgressAndDoneChallengeListResponseModel.swift
+//  ProgressChallengeListResponseModel.swift
 //  NEMODU
 //
 //  Created by Kime Heejae on 2022/10/31.
@@ -14,4 +14,4 @@ struct ProgressAndDoneChallengeListElement: Codable {
     let picturePaths: [String]
 }
 
-typealias ProgressAndDoneChallengeListResponseModel = [ProgressAndDoneChallengeListElement]
+typealias ProgressChallengeListResponseModel = [ProgressAndDoneChallengeListElement]

--- a/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
+++ b/NEMODU/NEMODU/Screen/ChallengeRanking/ViewController/Challenge/ChallengeVC.swift
@@ -40,11 +40,11 @@ class ChallengeVC : BaseViewController {
     
     var reloadCellIndex = 0
     
-    var invitedChallengeListResponseModel: InvitedChallengeListResponseModel?
+    var invitedChallengeListResponseModel: [InvitedChallengeListElement] = []
     
     var waitChallengeListResponseModel: WaitChallengeListResponseModel?
-    var progressChallengeListResponseModel: ProgressAndDoneChallengeListResponseModel?
-    var doneChallengeListResponseModel: ProgressAndDoneChallengeListResponseModel?
+    var progressChallengeListResponseModel: ProgressChallengeListResponseModel?
+    var doneChallengeListResponseModel: [ProgressAndDoneChallengeListElement] = []
     
     private let viewModel = ChallengeVM()
     
@@ -82,7 +82,6 @@ class ChallengeVC : BaseViewController {
         super.bindOutput()
         
         bindAPIErrorAlert(viewModel)
-        bindInvitedList()
         bindChallengeList()
     }
 
@@ -90,23 +89,23 @@ class ChallengeVC : BaseViewController {
     
     private func getChallengeList() {
         DispatchQueue.global().sync {
-            let beforeCntInvited = invitedChallengeListResponseModel?.count
+            let beforeCntInvited = invitedChallengeListResponseModel.count
             let beforeCntWait = waitChallengeListResponseModel?.count
             let beforeCntProgress = progressChallengeListResponseModel?.count
-            let beforeCntDone = doneChallengeListResponseModel?.count
+            let beforeCntDone = doneChallengeListResponseModel.count
 
             // 초대받은 챌린지
             viewModel.getInvitedChallengeList()
-            
+
             // 챌린지 내역
             viewModel.getWaitChallengeList()
             viewModel.getProgressChallengeList()
             viewModel.getDoneChallengeList()
 
-            if invitedChallengeListResponseModel?.count != beforeCntInvited ||
+            if invitedChallengeListResponseModel.count != beforeCntInvited ||
                 waitChallengeListResponseModel?.count != beforeCntWait ||
                 progressChallengeListResponseModel?.count != beforeCntProgress ||
-                doneChallengeListResponseModel?.count != beforeCntDone {
+                doneChallengeListResponseModel.count != beforeCntDone {
                 challengeTableView.reloadData()
             } else {
                 reloadChallengeTableView(toMoveIndex: reloadCellIndex)
@@ -194,7 +193,7 @@ extension ChallengeVC : UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
         case 0: // 초대받은 챌린지
-            return invitedChallengeListResponseModel?.count ?? 0
+            return invitedChallengeListResponseModel.count
         case 1: // 챌린지 내역 및 메뉴바
             return 0
         case 2: // 챌린지 목록
@@ -204,7 +203,7 @@ extension ChallengeVC : UITableViewDataSource {
             case 1: // 진행 중
                 return progressChallengeListResponseModel?.count ?? 0
             case 2: // 진행 완료
-                return doneChallengeListResponseModel?.count ?? 0
+                return doneChallengeListResponseModel.count
             default:
                 return 0
             }
@@ -218,8 +217,8 @@ extension ChallengeVC : UITableViewDataSource {
         case 0: // 초대받은 챌린지
             guard let cell = tableView.dequeueReusableCell(withIdentifier: InvitedChallengeTVC.className, for: indexPath) as? InvitedChallengeTVC else { return UITableViewCell() }
             cell.challengeVC = self
-            guard let invitedChallengeList = invitedChallengeListResponseModel else { return UITableViewCell() }
-            cell.configureInvitedChallengeTVC(invitedChallengeListElement: invitedChallengeList[indexPath.row])
+            cell.configureInvitedChallengeTVC(invitedChallengeListElement: invitedChallengeListResponseModel[indexPath.row])
+            
             return cell
             
         case 2: // 챌린지 목록
@@ -236,8 +235,7 @@ extension ChallengeVC : UITableViewDataSource {
                 return cell
             case 2: // 진행 완료
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: ChallengeFinishTVC.className, for: indexPath) as? ChallengeFinishTVC else { return UITableViewCell() }
-                guard let doneChallengeList = doneChallengeListResponseModel else { return UITableViewCell() }
-                cell.configureChallengeFinishTVC(doneChallengeListElement: doneChallengeList[indexPath.row])
+                cell.configureChallengeFinishTVC(doneChallengeListElement: doneChallengeListResponseModel[indexPath.row])
                 return cell
             default:
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: ChallengeListTVC.className, for: indexPath) as? ChallengeListTVC else { return UITableViewCell() }
@@ -320,8 +318,7 @@ extension ChallengeVC : UITableViewDelegate {
                 challengeHistoryDetailVC.hidesBottomBarWhenPushed = true
                 challengeHistoryDetailVC.configureChallengeDoneLayout()
                 
-                guard let doneChallengeList = doneChallengeListResponseModel else { return }
-                challengeHistoryDetailVC.getChallengeHistoryDetailInfo(uuid: doneChallengeList[indexPath.row].uuid)
+                challengeHistoryDetailVC.getChallengeHistoryDetailInfo(uuid: doneChallengeListResponseModel[indexPath.row].uuid)
                 
                 navigationController?.pushViewController(challengeHistoryDetailVC, animated: true)
             default:
@@ -360,7 +357,7 @@ extension ChallengeVC : UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         switch section {
         case 0: // 초대받은 챌린지
-            return invitedChallengeListResponseModel?.count ?? 0 == 0 ? 93 : .leastNormalMagnitude
+            return invitedChallengeListResponseModel.count == 0 ? 93 : .leastNormalMagnitude
         case 1: // 챌린지 내역 및 메뉴바
             return .leastNormalMagnitude
         case 2: // 챌린지 목록
@@ -370,7 +367,7 @@ extension ChallengeVC : UITableViewDelegate {
             case 1: // 진행 중
                 return progressChallengeListResponseModel?.count ?? 0 == 0 ? 93 : .leastNormalMagnitude
             case 2: // 진행 완료
-                return doneChallengeListResponseModel?.count ?? 0 == 0 ? 93 : .leastNormalMagnitude
+                return doneChallengeListResponseModel.count == 0 ? 93 : .leastNormalMagnitude
             default:
                 return 93
             }
@@ -402,18 +399,16 @@ extension ChallengeVC {
 // MARK: - Output
 
 extension ChallengeVC {
-    private func bindInvitedList() {
+    private func bindChallengeList() {
         viewModel.output.invitedChallengeList
             .subscribe(onNext: { [weak self] data in
                 guard let self = self else { return }
                 
-                self.invitedChallengeListResponseModel = data
+                self.invitedChallengeListResponseModel.append(contentsOf: data)
                 self.challengeTableView.reloadSections(IndexSet(0...0), with: .none)
             })
             .disposed(by: disposeBag)
-    }
-    
-    private func bindChallengeList() {
+        
         viewModel.output.waitChallengeList
             .subscribe(onNext: { [weak self] data in
                 guard let self = self else { return }
@@ -434,7 +429,24 @@ extension ChallengeVC {
             .subscribe(onNext: { [weak self] data in
                 guard let self = self else { return }
                 
-                self.doneChallengeListResponseModel = data
+                self.doneChallengeListResponseModel.append(contentsOf: data)
+            })
+            .disposed(by: disposeBag)
+        
+        challengeTableView.rx.willDisplayCell
+            .subscribe(onNext: { [weak self] cell, indexPath in
+                guard let self = self else { return }
+                
+                if indexPath.section == 0 &&
+                    self.invitedChallengeListResponseModel.count - 1 == indexPath.row {
+                    self.viewModel.getInvitedChallengeList()
+                }
+                
+                if indexPath.section == 2 &&
+                    self.reloadCellIndex == 2 &&
+                    self.doneChallengeListResponseModel.count - 1 == indexPath.row {
+                    self.viewModel.getDoneChallengeList()
+                }
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## PR 요약
챌린지 목록 중 목록이 많은 부분인 '초대받은 챌린지'와 '진행완료 챌린지'의 목록에 대해 한번에 많은 정보를 불러오는 문제를 개선하고자 페이징 구조를 도입하여 서버호출 코드를 변경하였습니다.

- 초대받은 챌린지 목록 페이징 구현
- 진행 완료 챌린지 목록 페이징 구현

## 변경 사항
- 기존 진행중, 진행완료 챌린지의 공통 ResponseModel 파일을 페이징으로 인해 각각 파일로 분리하였습니다

##  ScreenShot


#### Linked Issue
close #223

